### PR TITLE
chore: serve static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ A modular, Bootstrap 5–powered starter for building responsive social/streamin
 ```
 
 ## Getting Started
-1. Run `npm start` to launch a local static server via [`serve`](https://www.npmjs.com/package/serve).
-2. Open the printed URL (e.g., `http://localhost:3000/`) to view `index.html`.
+1. Run `npm start` to launch a local static server via [`live-server`](https://www.npmjs.com/package/live-server) on `http://127.0.0.1:5173/` without opening a browser.
+2. Open `http://127.0.0.1:5173/` in your browser to view `index.html`.
 
 ## Development Guidelines
 - Build layouts with Bootstrap's grid (`container[-fluid]`, `row`, `col-*`).
@@ -26,7 +26,7 @@ A modular, Bootstrap 5–powered starter for building responsive social/streamin
 - See [AGENTS.md](AGENTS.md) for complete contributing rules.
 
 ## Scripts
-- `npm start` – serve the project locally with `serve`.
+- `npm start` – serve the project locally with `live-server` on port 5173.
 - `npm test` – placeholder tests; run before committing.
 
 Happy hacking!

--- a/README.md
+++ b/README.md
@@ -16,10 +16,8 @@ A modular, Bootstrap 5–powered starter for building responsive social/streamin
 ```
 
 ## Getting Started
-1. Serve the project as static files:
-   - `npx serve .` or `npx http-server .`
-   - or run `npm start` to launch `node app.js`
-2. Open the printed URL (e.g., `http://localhost:5173/`).
+1. Run `npm start` to launch a local static server via [`serve`](https://www.npmjs.com/package/serve).
+2. Open the printed URL (e.g., `http://localhost:3000/`) to view `index.html`.
 
 ## Development Guidelines
 - Build layouts with Bootstrap's grid (`container[-fluid]`, `row`, `col-*`).
@@ -28,7 +26,7 @@ A modular, Bootstrap 5–powered starter for building responsive social/streamin
 - See [AGENTS.md](AGENTS.md) for complete contributing rules.
 
 ## Scripts
-- `npm start` – run the development server.
+- `npm start` – serve the project locally with `serve`.
 - `npm test` – placeholder tests; run before committing.
 
 Happy hacking!

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "node app.js",
+    "start": "npx serve .",
     "test": "echo \"No tests configured\" && exit 0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "npx serve .",
+    "start": "npx live-server --port=5173 --no-browser .",
     "test": "echo \"No tests configured\" && exit 0"
   }
 }


### PR DESCRIPTION
## Summary
- use `npx serve` for `npm start`
- document static server usage

## Testing
- `npm test`
- `npm start -- -l 3333` *(manually verified server responds, see logs)*
- `node -e "require('puppeteer')"` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b302ccad948324bfadbc6a4f322114