### PR TITLE
feat: customize user rail avatar frames

### DIFF
--- a/module/user-rail/user-rail.css
+++ b/module/user-rail/user-rail.css
@@ -1,7 +1,8 @@
 #chat-widget-messages .avatar-frame {
   position: relative;
-  width: 3rem;
-  height: 3rem;
+  width: var(--avatar-size);
+  height: var(--avatar-size);
+  overflow: visible;
 }
 
 #chat-widget-messages .avatar-frame.online::before,
@@ -31,22 +32,26 @@
   background-color: #adafca;
 }
 
-#chat-widget-messages .avatar-img,
-#chat-widget-messages .avatar-frame-img {
+#chat-widget-messages .avatar-img {
   width: 100%;
   height: 100%;
   border: none;
 }
 
 #chat-widget-messages .avatar-frame-img {
+  width: var(--frame);
+  height: var(--frame);
+  border: none;
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   pointer-events: none;
 }
 
 #chat-widget-messages {
   --avatar-size: 3rem;
+  --frame: calc(var(--avatar-size) + 0.25rem);
   --indicator-size: 0.5rem;
   --indicator-bar-width: 0.625rem;
 }


### PR DESCRIPTION
## Summary
- allow user rail avatar frames to overflow their container
- add `--frame` variable so frame images can be sized independently from avatars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3c448654483249eaeea8f7e0cba48