### PR TITLE
feat(user-rail): expose avatar frame via css variables

### DIFF
--- a/module/user-rail/user-rail.css
+++ b/module/user-rail/user-rail.css
@@ -1,7 +1,16 @@
+#chat-widget-messages {
+  --avatar-size: 3rem;
+  --frame-size: calc(var(--avatar-size) + 0.5rem);
+  --indicator-size: 0.5rem;
+  --indicator-bar-width: 0.625rem;
+  overflow: visible;
+}
+
 #chat-widget-messages .avatar-frame {
   position: relative;
-  width: 3rem;
-  height: 3rem;
+  width: var(--avatar-size);
+  height: var(--avatar-size);
+  overflow: visible;
 }
 
 #chat-widget-messages .avatar-frame.online::before,
@@ -31,8 +40,7 @@
   background-color: #adafca;
 }
 
-#chat-widget-messages .avatar-img,
-#chat-widget-messages .avatar-frame-img {
+#chat-widget-messages .avatar-img {
   width: 100%;
   height: 100%;
   border: none;
@@ -40,15 +48,12 @@
 
 #chat-widget-messages .avatar-frame-img {
   position: absolute;
-  top: 0;
-  left: 0;
+  top: 50%;
+  left: 50%;
+  width: var(--frame-size);
+  height: var(--frame-size);
+  transform: translate(-50%, -50%);
   pointer-events: none;
-}
-
-#chat-widget-messages {
-  --avatar-size: 3rem;
-  --indicator-size: 0.5rem;
-  --indicator-bar-width: 0.625rem;
 }
 
 #chat-widget-messages .chat-widget-message {

--- a/module/user-rail/user-rail.html
+++ b/module/user-rail/user-rail.html
@@ -1,4 +1,4 @@
-<aside id="chat-widget-messages" class="chat-widget closed sidebar right">
+<aside id="chat-widget-messages" class="chat-widget closed sidebar right" style="--avatar-size:3rem; --frame-size:calc(var(--avatar-size) + 0.5rem);">
     <div class="chat-widget-messages">
       <div class="chat-widget-message has-notification" style="--accent:#ff78cb;">
       <div class="user-status d-flex align-items-center">


### PR DESCRIPTION
## Summary
- allow user rail avatar frames to overflow and size via CSS variables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b45dc98b34832480e5f757d5e56c78