### PR TITLE
Add navigation sidebar module

### DIFF
--- a/app.js
+++ b/app.js
@@ -142,6 +142,26 @@ class ModuleHub {
 /* ---------- Loader ---------- */
 const hub = new ModuleHub();
 
+let activeMainModule =
+  document.querySelector('main module[data-module]')?.getAttribute('data-module') ||
+  null;
+async function LoadMainModule(name) {
+  if (!name || name === activeMainModule) return;
+  const main = document.querySelector('main');
+  if (activeMainModule) {
+    await hub.destroy(activeMainModule);
+    main
+      .querySelector(`module[data-module="${activeMainModule}"]`)
+      ?.remove();
+  }
+  const node = document.createElement('module');
+  node.setAttribute('data-module', name);
+  node.setAttribute('data-css', 'true');
+  main.appendChild(node);
+  activeMainModule = name;
+}
+window.LoadMainModule = LoadMainModule;
+
 function parseProps(node) {
   const raw = node.getAttribute('data-props');
   if (!raw) return {};

--- a/index.html
+++ b/index.html
@@ -10,13 +10,13 @@
 </head>
 <body>
 
+  <!-- Navigation sidebar -->
+  <module data-module="navigation" data-css="true"></module>
+
   <!-- Header module -->
   <module data-module="header" data-css="true"></module>
 
-  <main class="container my-4">
-    <!-- Messages module -->
-    <module data-module="messages" data-css="true"></module>
-  </main>
+  <main class="container my-4"></main>
 
   <!-- SVG sprite mount -->
   <module data-module="svgs"></module>

--- a/module/header/header.css
+++ b/module/header/header.css
@@ -43,18 +43,6 @@
   text-transform: uppercase;
 }
 
-[data-role="header"] .sidemenu-trigger {
-  background: none;
-  border: none;
-  padding: 0;
-  margin-left: 30px;
-  display: none;
-}
-
-[data-role="header"] .sidemenu-trigger .icon-hamburger {
-  fill: #fff;
-}
-
 [data-role="header"] .navigation .icon-dots {
   fill: #fff;
 }
@@ -394,9 +382,6 @@
   }
   [data-role="header"] .navigation {
     display: none;
-  }
-  [data-role="header"] .header-actions .sidemenu-trigger {
-    display: flex;
   }
   [data-role="header"] .search-bar {
     padding: 0 0 0 20px;

--- a/module/header/header.js
+++ b/module/header/header.js
@@ -10,13 +10,10 @@ export default async function init({ hub, root, utils }) {
   root.innerHTML = `
     <header data-role="header" class="header">
       <div class="header-actions brand-group">
-        <a class="header-brand" href="#" data-role="brand">
+        <a class="header-brand" href="#" data-role="brand" title="Navigation">
           <svg class="logo" width="40" height="40"><use xlink:href="#svg-logo-vikinger"></use></svg>
           <h1 class="header-brand-text">NOIZ</h1>
         </a>
-        <button class="sidemenu-trigger" type="button" aria-label="Menu">
-          <svg class="icon-hamburger" width="20" height="20"><use xlink:href="#svg-hamburger"></use></svg>
-        </button>
       </div>
 
       <div class="header-actions">
@@ -214,6 +211,11 @@ export default async function init({ hub, root, utils }) {
   const searchWrap = root.querySelector('[data-role="search"]');
   const searchInput = searchWrap?.querySelector('input');
   const clearBtn = searchWrap?.querySelector('[data-role="clear"]');
+
+  utils.listen(brand, 'click', async (e) => {
+    e.preventDefault();
+    await hub.api.navigation.toggle?.();
+  });
 
   function updateSearch() {
     if (!searchWrap || !searchInput) return;

--- a/module/navigation/navigation.css
+++ b/module/navigation/navigation.css
@@ -1,0 +1,246 @@
+.navigation-small {
+  position: fixed;
+  top: 80px;
+  left: 0;
+  height: calc(100vh - 80px);
+  width: 80px;
+  padding-top: 20px;
+  background-color: #ffffff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-right: 1px solid #e5e7eb;
+  z-index: 1040;
+}
+.navigation-small.hidden {
+  display: none;
+}
+.navigation-avatar {
+  position: relative;
+  width: 48px;
+  height: 48px;
+  margin-bottom: 32px;
+}
+
+.navigation-avatar .avatar-image {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+}
+
+.navigation-avatar .avatar-frame {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 64px;
+  height: 64px;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+.navigation-small-menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  align-items: center;
+}
+.navigation-small-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  color: #8b97b7;
+  border-radius: 12px;
+  text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+.navigation-small-link:hover {
+  background-color: #f0f2f5;
+  color: #1f2937;
+}
+.navigation-small-link::after {
+  content: attr(data-title);
+  position: absolute;
+  left: 60px;
+  top: 50%;
+  transform: translateY(-50%) translateX(10px);
+  background-color: #1d2333;
+  color: #fff;
+  padding: 4px 8px;
+  border-radius: 12px;
+  font-size: 14px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+.navigation-small-link:hover::after {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+.navigation-large {
+  position: fixed;
+  top: 80px;
+  left: 10px;
+  height: calc(100vh - 80px);
+  width: 265px;
+  background-color: #ffffff;
+  border-right: 1px solid #e5e7eb;
+  transform: translateX(-100%);
+  transition: transform 0.3s ease;
+  z-index: 1030;
+  overflow-y: auto;
+}
+
+.navigation-large.open {
+  transform: translateX(0);
+}
+
+.navigation-large-profile {
+  position: relative;
+  padding: 80px 20px 20px;
+  text-align: center;
+}
+
+.navigation-large-profile .profile-banner {
+  display: block;
+  width: calc(100% + 30px);
+  height: 80px;
+  margin: -80px -10px 0;
+}
+
+.navigation-large-profile .avatar-wrap {
+  position: relative;
+  width: 90px;
+  height: 90px;
+  margin: -45px auto 20px;
+}
+
+.navigation-large-profile .avatar-image {
+  width: 90px;
+  height: 90px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.navigation-large-profile .avatar-frame {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 116px;
+  height: 116px;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+}
+
+
+.navigation-large-profile .user-name {
+  font-family: "Rajdhani", sans-serif;
+  font-weight: 700;
+  font-size: 1.125rem;
+  margin-bottom: 0;
+}
+
+.navigation-large-profile .user-url {
+  font-size: 0.875rem;
+  color: #8b97b7;
+  margin-bottom: 20px;
+}
+
+.profile-stats {
+  display: flex;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 30px;
+  background-color: #1d2333;
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.profile-stat {
+  flex: 1;
+  padding: 8px 0;
+  text-align: center;
+}
+
+.profile-stat:not(:last-child) {
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.profile-stat .stat-value {
+  display: block;
+  font-family: "Rajdhani", sans-serif;
+  font-weight: 700;
+  font-size: 0.875rem;
+  color: #e5e7eb;
+}
+
+.profile-stat .stat-label {
+  display: block;
+  font-size: 0.75rem;
+  color: #8b97b7;
+  text-transform: uppercase;
+}
+
+.user-badges {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  list-style: none;
+  padding: 0;
+  margin: 0 0 30px;
+}
+
+.user-badges .badge-icon {
+  width: 24px;
+  height: 24px;
+  display: block;
+  fill: currentColor;
+}
+
+.navigation-large-menu {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 20px;
+}
+
+.navigation-large-link {
+  display: flex;
+  align-items: center;
+  padding: 12px 20px;
+  color: #1f2937;
+  text-decoration: none;
+  font-family: "Rajdhani", sans-serif;
+  font-weight: 500;
+  transition: background-color 0.2s ease;
+}
+
+.navigation-large-link .icon {
+  margin-right: 12px;
+  fill: currentColor;
+}
+
+.navigation-large-link:hover {
+  background-color: #f0f2f5;
+  color: #1f2937;
+}
+
+@media (max-width: 991.98px) {
+  .navigation-small,
+  .navigation-large {
+    display: none;
+  }
+  .navigation-large.mobile-open {
+    display: block;
+    left: 0;
+    transform: translateX(0);
+  }
+}

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -1,0 +1,139 @@
+export default async function init({ hub, root, utils }) {
+  const links = [
+    { title: 'Newsfeed', module: 'newsfeed', icon: '#svg-newsfeed' },
+    { title: 'Overview', module: 'overview', icon: '#svg-overview' },
+    { title: 'Groups', module: 'groups', icon: '#svg-group' },
+    { title: 'Members', module: 'members', icon: '#svg-members' },
+    { title: 'Badges', module: 'badges', icon: '#svg-badges' },
+    { title: 'Quests', module: 'quests', icon: '#svg-quests' },
+    { title: 'Streams', module: 'streams', icon: '#svg-streams' },
+    { title: 'Events', module: 'events', icon: '#svg-events' },
+    { title: 'Forums', module: 'forums', icon: '#svg-forums' },
+    { title: 'Marketplace', module: 'marketplace', icon: '#svg-marketplace' }
+  ];
+
+  root.innerHTML = `
+    <nav class="navigation-small" data-role="small">
+      <a href="#" class="navigation-avatar">
+        <img
+          class="avatar-image"
+          src="https://odindesignthemes.com/vikinger/img/avatar/01.jpg"
+          alt="User avatar"
+        />
+        <img
+          class="avatar-frame"
+          src="https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/decorations/dragons_smile.png"
+          alt=""
+          aria-hidden="true"
+        />
+      </a>
+      <ul class="navigation-small-menu">
+        ${links
+          .map(
+            (l) => `
+        <li class="navigation-small-item">
+          <a href="#" class="navigation-small-link" data-title="${l.title}" data-module="${l.module}">
+            <svg class="icon" width="20" height="20"><use xlink:href="${l.icon}"></use></svg>
+          </a>
+        </li>`
+          )
+          .join('')}
+      </ul>
+    </nav>
+    <nav class="navigation-large" data-role="large">
+      <div class="navigation-large-profile">
+        <img
+          class="profile-banner"
+          src="https://raw.githubusercontent.com/ItsPi3141/discord-fake-avatar-decorations/refs/heads/main/public/nameplates/d20_roll.png"
+          alt=""
+          aria-hidden="true"
+        />
+        <div class="avatar-wrap">
+          <img
+            class="avatar-image"
+            src="https://odindesignthemes.com/vikinger/img/avatar/01.jpg"
+            alt="User avatar"
+          />
+          <img
+            class="avatar-frame"
+            src="https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/decorations/dragons_smile.png"
+            alt=""
+            aria-hidden="true"
+          />
+        </div>
+        <h3 class="user-name">Marina Valentine</h3>
+        <p class="user-url">www.gamehuntress.com</p>
+        <ul class="profile-stats">
+          <li class="profile-stat"><span class="stat-value">930</span><span class="stat-label">Posts</span></li>
+          <li class="profile-stat"><span class="stat-value">82</span><span class="stat-label">Friends</span></li>
+          <li class="profile-stat"><span class="stat-value">5.7K</span><span class="stat-label">Visits</span></li>
+        </ul>
+        <ul class="user-badges">
+          <li><svg class="badge-icon" width="24" height="24"><use xlink:href="#svg-facebook"></use></svg></li>
+          <li><svg class="badge-icon" width="24" height="24"><use xlink:href="#svg-twitter"></use></svg></li>
+          <li><svg class="badge-icon" width="24" height="24"><use xlink:href="#svg-instagram"></use></svg></li>
+          <li><svg class="badge-icon" width="24" height="24"><use xlink:href="#svg-discord"></use></svg></li>
+          <li><svg class="badge-icon" width="24" height="24"><use xlink:href="#svg-google"></use></svg></li>
+        </ul>
+      </div>
+      <ul class="navigation-large-menu">
+        ${links
+          .map(
+            (l) => `
+        <li class="navigation-large-item">
+          <a href="#" class="navigation-large-link" data-module="${l.module}">
+            <svg class="icon" width="20" height="20"><use xlink:href="${l.icon}"></use></svg>
+            <span>${l.title}</span>
+          </a>
+        </li>`
+          )
+          .join('')}
+      </ul>
+    </nav>
+  `;
+
+  const small = root.querySelector('[data-role="small"]');
+  const large = root.querySelector('[data-role="large"]');
+
+  utils.delegate(root, 'click', '.navigation-small-link, .navigation-large-link', (e, link) => {
+    e.preventDefault();
+    const mod = link.getAttribute('data-module');
+    if (mod) window.LoadMainModule(mod);
+  });
+
+  const api = {
+    showSmall() {
+      large.classList.remove('mobile-open');
+      if (large.classList.contains('open')) {
+        large.addEventListener(
+          'transitionend',
+          () => {
+            small.classList.remove('hidden');
+          },
+          { once: true }
+        );
+        large.classList.remove('open');
+      } else {
+        small.classList.remove('hidden');
+      }
+    },
+    showLarge() {
+      small.classList.add('hidden');
+      large.classList.remove('mobile-open');
+      requestAnimationFrame(() => {
+        large.classList.add('open');
+      });
+    },
+    toggle() {
+      if (window.innerWidth < 992) {
+        large.classList.toggle('mobile-open');
+      } else if (large.classList.contains('open')) {
+        api.showSmall();
+      } else {
+        api.showLarge();
+      }
+    }
+  };
+
+  return api;
+}

--- a/module/newsfeed/newsfeed.css
+++ b/module/newsfeed/newsfeed.css
@@ -1,0 +1,3 @@
+.newsfeed {
+  padding: 1rem;
+}

--- a/module/newsfeed/newsfeed.js
+++ b/module/newsfeed/newsfeed.js
@@ -1,0 +1,8 @@
+export default async function init({ root }) {
+  root.innerHTML = `
+    <section class="newsfeed">
+      <h2>Newsfeed</h2>
+      <p>Latest updates will appear here.</p>
+    </section>
+  `;
+}

--- a/module/overview/overview.css
+++ b/module/overview/overview.css
@@ -1,0 +1,3 @@
+.overview {
+  padding: 1rem;
+}

--- a/module/overview/overview.js
+++ b/module/overview/overview.js
@@ -1,0 +1,8 @@
+export default async function init({ root }) {
+  root.innerHTML = `
+    <section class="overview">
+      <h2>Overview</h2>
+      <p>User overview goes here.</p>
+    </section>
+  `;
+}


### PR DESCRIPTION
## Summary
- enlarge large navigation banner so avatar overlaps banner halfway with more spacing from top
- restyle large navigation profile stats with dark pill background and separators
- load modules from navigation links into the main area and include sample Newsfeed and Overview modules
- expose `LoadMainModule` globally in `app.js` and delegate navigation clicks to it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f9dbc7648324b42e21e57232246e