### PR TITLE
docs: document module service layer

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,6 +4,7 @@ This project is built with a mobile-first mindset using Bootstrap 4. Follow thes
 
 ## Layout & Modules
 - `index.html` uses `<module>` elements with `data-module` attributes as mount points. Place each module in `module/<name>/<name.{html,css,js}>`.
+- Modules may expose an optional `<name>.service.js` that registers the module's API with `hub`. These services load at startup for entries in `modules-enabled.json` so their functions are available before the UI mounts.
 - Build layouts with Bootstrap's grid (`container[-fluid]`, `row`, `col-*`).
 - Prefer responsive utility classes and relative units; avoid fixed pixel widths or heights unless guarded by media queries.
 - Ensure modules collapse or stack on small viewports. Test changes in browser DevTools' device mode (e.g., iPhone 12).

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,14 +6,22 @@ A modular, Bootstrap 5–powered starter for building responsive social/streamin
 ```
 .
 ├── index.html      # Page skeleton with <module> mount points
-├── app.js          # Module loader and event bus
+├── app.js          # Module loader, service loader, and event bus
 ├── app.css         # Global styles + module imports
+├── modules-enabled.json # Lists modules to mount and services to preload
 ├── module/         # One folder per module
+│   └── <name>/
+│       ├── <name>.js           # UI logic (lazy loaded)
+│       └── <name>.service.js   # Optional service API loaded at startup
 ├── data/           # JSON fixtures that drive the UI
 ├── images/         # Static assets
 ├── scripts/        # Helper scripts for data generation
 └── package.json    # npm scripts
 ```
+
+## Module Services
+- During startup, `app.js` reads `modules-enabled.json` and eagerly imports `<module>/<name>.service.js` when present.
+- Each service registers its API with the global `hub`, letting other modules call it before the corresponding UI is mounted.
 
 ## Getting Started
 1. Run `npm start` to launch a local static server via [`live-server`](https://www.npmjs.com/package/live-server) on `http://127.0.0.1:5173/` without opening a browser.


### PR DESCRIPTION
## Summary
- describe optional `<name>.service.js` files for modules
- update project README with service loader and modules-enabled.json info

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b749263a7c8324b4a3c255518e4d87