### PR TITLE
docs: clarify dynamic module markup and project structure

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,11 +11,10 @@ A modular, Bootstrap 5–powered starter for building responsive social/streamin
 ├── modules-enabled.json # Lists modules to mount and services to preload
 ├── module/         # One folder per module
 │   └── <name>/
-│       ├── <name>.js           # UI logic (lazy loaded)
+│       ├── <name>.js           # UI logic; generates markup dynamically (no separate HTML)
 │       └── <name>.service.js   # Optional service API loaded at startup
 ├── data/           # JSON fixtures that drive the UI
 ├── images/         # Static assets
-├── scripts/        # Helper scripts for data generation
 └── package.json    # npm scripts
 ```
 


### PR DESCRIPTION
## Summary
- Remove `scripts/` from the Project Structure tree
- Note that modules generate UI markup dynamically in `<name>.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74da5ab0483248ae8f485770c1721