### PR TITLE
Allow opting into service modules in config

### DIFF
--- a/app.js
+++ b/app.js
@@ -143,7 +143,8 @@ class ModuleHub {
 /* ---------- Loader ---------- */
 const hub = new ModuleHub();
 
-// Load service modules early so their APIs are available via hub.require()
+// Load service modules early so their APIs are available via hub.require().
+// Only modules with `services: true` in modules-enabled.json are loaded.
 async function loadServices() {
   let config = {};
   try {
@@ -153,7 +154,7 @@ async function loadServices() {
     console.error('[NOIZ] Failed to load modules-enabled.json', err);
   }
 
-  const enabled = Object.values(config).filter(m => m?.status === 'enabled');
+  const enabled = Object.values(config).filter(m => m?.status === 'enabled' && m?.services);
   for (const { name } of enabled) {
     try {
       const svc = await import(`/module/${name}/${name}.service.js`);

--- a/modules-enabled.json
+++ b/modules-enabled.json
@@ -4,62 +4,71 @@
     "icon": "bars",
     "status": "enabled",
     "navigation": false,
-    "header": false
+    "header": false,
+    "services": false
   },
   "header": {
     "name": "header",
     "icon": "home",
     "status": "enabled",
     "navigation": false,
-    "header": false
+    "header": false,
+    "services": false
   },
   "user-rail": {
     "name": "user-rail",
     "icon": "user-group",
     "status": "enabled",
     "navigation": false,
-    "header": false
+    "header": false,
+    "services": false
   },
   "svgs": {
     "name": "svgs",
     "icon": "images",
     "status": "enabled",
     "navigation": false,
-    "header": false
+    "header": false,
+    "services": false
   },
   "newsfeed": {
     "name": "newsfeed",
     "icon": "newsfeed",
     "status": "enabled",
     "navigation": true,
-    "header": false
+    "header": false,
+    "services": false
   },
   "messages": {
     "name": "messages",
     "icon": "messages",
     "status": "enabled",
     "navigation": true,
-    "header": true
+    "header": true,
+    "services": false
   },
   "profile": {
     "name": "profile",
     "icon": "profile",
     "status": "enabled",
     "navigation": true,
-    "header": false
+    "header": false,
+    "services": false
   },
   "overview": {
     "name": "overview",
     "icon": "overview",
     "status": "enabled",
     "navigation": true,
-    "header": false
+    "header": false,
+    "services": false
   },
   "notifications": {
     "name": "notifications",
     "icon": "notification",
     "status": "enabled",
     "navigation": false,
-    "header": true
+    "header": true,
+    "services": false
   }
 }


### PR DESCRIPTION
## Summary
- add `services` flag to `modules-enabled.json`
- load service modules only when `services: true`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b751b9fecc8324a7ae2fe00e0461be