### PR TITLE
Show quest and settings buttons only when modules disabled

### DIFF
--- a/module/header/header.js
+++ b/module/header/header.js
@@ -198,6 +198,13 @@ export default async function init({ hub, root, utils }) {
     </header>
   `;
 
+  if (mods.quests?.status === 'enabled') {
+    root.querySelector('.quest')?.closest('.header-actions')?.remove();
+  }
+  if (mods.settings?.status === 'enabled') {
+    root.querySelector('.settings-button')?.remove();
+  }
+
   const slots = {
     right: root.querySelector('[data-slot="right"]')
   };


### PR DESCRIPTION
## Summary
- Load quest button only if quests module is disabled
- Load settings button only if settings module is disabled

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b75d527ee48324b9e53cc58af81e47