### PR TITLE
Load logged-in user for profile route

### DIFF
--- a/app.js
+++ b/app.js
@@ -335,9 +335,19 @@ async function handleRoute() {
   if (match) {
     const mod = match[1];
     const slug = match[2];
-    if (mod === 'profile' && slug) {
-      const user = await getUserBySlug(decodeURIComponent(slug));
-      LoadMainModule('profile', user ? { user } : {});
+    if (mod === 'profile') {
+      if (slug) {
+        const user = await getUserBySlug(decodeURIComponent(slug));
+        LoadMainModule('profile', user ? { user } : {});
+      } else {
+        try {
+          const loggedSlug = await fetch('/data/logged-in.json').then(r => r.json());
+          const user = loggedSlug ? await getUserBySlug(loggedSlug) : null;
+          LoadMainModule('profile', user ? { user } : {});
+        } catch {
+          LoadMainModule('profile');
+        }
+      }
     } else {
       LoadMainModule(mod);
     }

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -89,7 +89,16 @@ export default async function init({ hub, root, utils }) {
   utils.delegate(root, 'click', '.navigation-small-link, .navigation-large-link', (e, link) => {
     e.preventDefault();
     const mod = link.getAttribute('data-module');
-    if (mod) window.LoadMainModule(mod);
+    if (mod === 'profile') {
+      window.LoadMainModule('profile', { user: currentUser });
+    } else if (mod) {
+      window.LoadMainModule(mod);
+    }
+  });
+
+  utils.delegate(root, 'click', '.navigation-avatar', (e) => {
+    e.preventDefault();
+    window.LoadMainModule('profile', { user: currentUser });
   });
 
   // Tooltip handling for compact navigation


### PR DESCRIPTION
## Summary
- Load logged-in user's profile when navigating to `#/profile` without a slug
- Ensure navigation links and avatar open the current user's profile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b777c93df08324b292f4f1ec422d59