### PR TITLE
Clear header search input on result selection

### DIFF
--- a/module/header/header.js
+++ b/module/header/header.js
@@ -294,6 +294,14 @@ export default async function init({ hub, root, utils }) {
     searchInput.focus();
   });
 
+  if (searchDropdown) {
+    utils.delegate(searchDropdown, 'click', '.header-search-item', () => {
+      if (!searchInput) return;
+      searchInput.value = '';
+      updateSearch();
+    });
+  }
+
   utils.listen(document, 'click', (e) => {
     if (!searchWrap?.contains(e.target)) {
       renderResults({});


### PR DESCRIPTION
## Summary
- clear search input when a search result is clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b85fd202e483248c6ce0f1d420fa20