### PR TITLE
Add sidebar chat module

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <main class="content-grid" style="transform: translate(200.5px); transition: transform 0.4s ease-in-out;"></main>
 
   <!-- User rail module -->
+  <module data-module="chat" data-css="true"></module>
   <module data-module="user-rail" data-css="true" class="d-none d-lg-flex"></module>
 
   <!-- SVG sprite mount -->

--- a/module/chat/chat.css
+++ b/module/chat/chat.css
@@ -1,0 +1,83 @@
+module[data-module="chat"] {
+  position: fixed;
+  top: 80px;
+  right: 72px;
+  width: 360px;
+  height: calc(100vh - 80px);
+  background: #fff;
+  box-shadow: -4px 0 8px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  z-index: 1030;
+}
+
+module[data-module="chat"] .chat-header {
+  padding: 8px 12px;
+  border-bottom: 1px solid #ddd;
+}
+
+module[data-module="chat"] .chat-header .title {
+  font-weight: 600;
+}
+
+module[data-module="chat"] .chat-header .meta {
+  font-size: 12px;
+  color: #666;
+}
+
+module[data-module="chat"] .chat-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+
+module[data-module="chat"] .chat-message {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+module[data-module="chat"] .chat-message .time {
+  color: #888;
+}
+
+module[data-module="chat"] .chat-message .name {
+  font-weight: 600;
+}
+
+module[data-module="chat"] .chat-form {
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  border-top: 1px solid #ddd;
+}
+
+module[data-module="chat"] .chat-input {
+  flex: 1;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 4px 8px;
+}
+
+module[data-module="chat"] .chat-hide {
+  border-top: 1px solid #ddd;
+  width: 100%;
+  text-align: center;
+  color: #06c;
+  padding: 6px;
+  background: #fff;
+}
+
+module[data-module="chat"] .chat-donation {
+  background: #e9ffe5;
+  border-radius: 6px;
+  padding: 8px;
+  margin: 4px 0;
+}
+
+module[data-module="chat"] .donation-header {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+}

--- a/module/chat/chat.css
+++ b/module/chat/chat.css
@@ -47,17 +47,40 @@ module[data-module="chat"] .chat-message .name {
 }
 
 module[data-module="chat"] .chat-form {
-  display: flex;
-  gap: 8px;
   padding: 8px;
   border-top: 1px solid #ddd;
 }
 
+module[data-module="chat"] .chat-input-group {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  border: 1px solid #ccc;
+  border-radius: 16px;
+  overflow: hidden;
+}
+
 module[data-module="chat"] .chat-input {
   flex: 1;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  padding: 4px 8px;
+  border: none;
+  padding: 6px 40px 6px 12px;
+  outline: none;
+}
+
+module[data-module="chat"] .chat-send-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0 12px;
+}
+
+module[data-module="chat"] .chat-send-icon {
+  width: 20px;
+  height: 20px;
+  fill: #06c;
 }
 
 module[data-module="chat"] .chat-hide {

--- a/module/chat/chat.js
+++ b/module/chat/chat.js
@@ -1,0 +1,83 @@
+// module/chat/chat.js
+// Simple sidebar chat module with mock data and basic send capability
+
+const messageTpl = (m) => {
+  if (m.type === 'donation') {
+    return `
+      <div class="chat-donation">
+        <div class="donation-header">
+          <span class="name">${m.user}</span>
+          <span class="amount">${m.amount}</span>
+        </div>
+        ${m.text ? `<div class="donation-text">${m.text}</div>` : ''}
+      </div>
+    `;
+  }
+  return `
+    <div class="chat-message">
+      <span class="time">${m.time}</span>
+      <span class="name" style="color:${m.color || '#333'}">${m.user}</span>
+      <span class="text">${m.text}</span>
+    </div>
+  `;
+};
+
+const tpl = (messages) => `
+  <div class="chat-header">
+    <div class="title">Live chat</div>
+    <div class="meta">Top chat • 283K</div>
+  </div>
+  <div class="chat-body" data-role="list">
+    ${messages.map(messageTpl).join('')}
+  </div>
+  <form class="chat-form" data-role="form">
+    <input type="text" class="chat-input" data-role="input" placeholder="Say something..." maxlength="200" />
+    <button type="submit" class="btn btn-primary btn-sm">Send</button>
+  </form>
+  <button type="button" class="chat-hide btn btn-link" data-action="hide">Hide chat</button>
+`;
+
+export default async function init({ root, utils }) {
+  let messages = [
+    { time: '9:58 AM', user: 'Lena', color: '#07b', text: 'wow' },
+    { time: '9:58 AM', user: 'Ash', color: '#0a0', text: 'more pushups!' },
+    { time: '9:58 AM', user: 'IntroMeb', color: '#c00', text: 'great play!' },
+    { time: '9:58 AM', user: 'Chankonabe', color: '#b80', text: "how's everyone on the eh team doing?" },
+    { time: '9:58 AM', user: 'pexelwiz', color: '#609', text: 'awesome! 👏' },
+    { type: 'donation', user: 'Laura Ipsum', amount: '$5.00', text: 'BRAVO 🦊' }
+  ];
+
+  function render() {
+    root.innerHTML = tpl(messages);
+    const list = root.querySelector('[data-role="list"]');
+    list.scrollTop = list.scrollHeight;
+  }
+
+  render();
+
+  utils.delegate(root, 'submit', '[data-role="form"]', (e) => {
+    e.preventDefault();
+    const input = root.querySelector('[data-role="input"]');
+    const text = input.value.trim();
+    if (!text) return;
+    messages.push({
+      time: new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }),
+      user: 'Anon',
+      color: '#333',
+      text
+    });
+    input.value = '';
+    render();
+  });
+
+  utils.delegate(root, 'click', '[data-action="hide"]', () => {
+    root.style.display = 'none';
+  });
+
+  return {
+    addMessage(m) {
+      messages.push(m);
+      render();
+    }
+  };
+}

--- a/module/chat/chat.js
+++ b/module/chat/chat.js
@@ -31,8 +31,14 @@ const tpl = (messages) => `
     ${messages.map(messageTpl).join('')}
   </div>
   <form class="chat-form" data-role="form">
-    <input type="text" class="chat-input" data-role="input" placeholder="Say something..." maxlength="200" />
-    <button type="submit" class="btn btn-primary btn-sm">Send</button>
+    <div class="chat-input-group">
+      <input type="text" class="chat-input" data-role="input" placeholder="Say something..." maxlength="200" />
+      <button type="submit" class="chat-send-btn" aria-label="Send">
+        <svg class="chat-send-icon" viewBox="0 0 24 24">
+          <path d="M2 21L23 12 2 3v7l15 2-15 2z" />
+        </svg>
+      </button>
+    </div>
   </form>
   <button type="button" class="chat-hide btn btn-link" data-action="hide">Hide chat</button>
 `;

--- a/modules-enabled.json
+++ b/modules-enabled.json
@@ -70,5 +70,13 @@
     "navigation": false,
     "header": true,
     "services": true
+  },
+  "chat": {
+    "name": "chat",
+    "icon": "messages",
+    "status": "enabled",
+    "navigation": false,
+    "header": false,
+    "services": false
   }
 }


### PR DESCRIPTION
## Summary
- add basic chat sidebar module with mock messages and send capability
- style chat panel and donation messages
- register chat module and mount in index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b892c2f3188324972bd61a3b7afb87