### PR TITLE
feat: add mini profile popup

### DIFF
--- a/AlignmentItem.html
+++ b/AlignmentItem.html
@@ -3205,7 +3205,7 @@ body { overflow-x: hidden; }
         { emoji: '🟣', tip: 'Partner' },
         { emoji: '🎮', tip: 'Controller' },
       ],
-      about: 'Just vibing and building NOIZ-UI.',
+      bio: 'Just vibing and building NOIZ-UI.',
       stats: [{ n: '12.3k', label: 'Followers' }, { n: '254', label: 'Subs' }, { n: '98', label: 'Clips' }],
     },
     u_2: {
@@ -3219,7 +3219,7 @@ body { overflow-x: hidden; }
         { emoji: '🟣', tip: 'Partner' },
         { emoji: '🎙️', tip: 'Mic On' },
       ],
-      about: 'Grinding dubs — customs & chill.',
+      bio: 'Grinding dubs — customs & chill.',
       stats: [{ n: '81k', label: 'Followers' }, { n: '3.2k', label: 'Subs' }, { n: '412', label: 'Clips' }],
     },
     u_3: {
@@ -3232,7 +3232,7 @@ body { overflow-x: hidden; }
         { emoji: '💎', tip: 'Top Supporter' },
         { emoji: '🎉', tip: 'Event Winner' },
       ],
-      about: 'I click things so tooltips appear.',
+      bio: 'I click things so tooltips appear.',
       stats: [{ n: '1.2k', label: 'Messages' }, { n: '36', label: 'Gifts' }, { n: '7', label: 'Clips' }],
     }
   };
@@ -3308,7 +3308,7 @@ body { overflow-x: hidden; }
     });
 
     // About
-    about.textContent = user.about || '';
+    about.textContent = user.bio || '';
 
     // Stats
     stats.innerHTML = '';

--- a/app.js
+++ b/app.js
@@ -171,8 +171,11 @@ async function loadServices() {
 }
 await loadServices();
 
+// Determine the currently mounted main module, ignoring persistent overlays
 let activeMainModule =
-  document.querySelector('main module[data-module]')?.getAttribute('data-module') ||
+  document
+    .querySelector('main module[data-module]:not([data-module="profile-overlay"])')
+    ?.getAttribute('data-module') ||
   null;
 async function LoadMainModule(name, props = {}) {
   if (!name) return;

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // app.js
 // NOIZ Hub + Loader with lifecycle-safe modules and optional per-module CSS loading.
-import { getUserBySlug } from './module/users.js';
+import { getUserByToken } from './module/users.js';
 
 class ModuleHub {
   constructor() {
@@ -182,8 +182,8 @@ async function LoadMainModule(name, props = {}) {
 
   let targetHash = `#/${name}`;
   if (name === 'profile') {
-    const slug = props?.user?.slug;
-    if (slug) targetHash = `#/profile/${slug}`;
+    const token = props?.user?.token;
+    if (token) targetHash = `#/profile/${token}`;
   }
   if (window.location.hash !== targetHash) {
     window.history.pushState(null, '', targetHash);
@@ -191,9 +191,9 @@ async function LoadMainModule(name, props = {}) {
   const main = document.querySelector('main');
   if (name === activeMainModule) {
     const existing = main.querySelector(`module[data-module="${name}"]`);
-    const currentSlug = parseProps(existing).user?.slug;
-    const nextSlug = props?.user?.slug;
-    if (currentSlug === nextSlug) return;
+    const currentToken = parseProps(existing).user?.token;
+    const nextToken = props?.user?.token;
+    if (currentToken === nextToken) return;
     await hub.destroy(name);
     existing?.remove();
   } else if (activeMainModule) {
@@ -337,15 +337,15 @@ async function handleRoute() {
   const match = route.match(/^\/([^/]+)(?:\/([^/]+))?/);
   if (match) {
     const mod = match[1];
-    const slug = match[2];
+    const token = match[2];
     if (mod === 'profile') {
-      if (slug) {
-        const user = await getUserBySlug(decodeURIComponent(slug));
+      if (token) {
+        const user = await getUserByToken(decodeURIComponent(token));
         LoadMainModule('profile', user ? { user } : {});
       } else {
         try {
-          const loggedSlug = await fetch('/data/logged-in.json').then(r => r.json());
-          const user = loggedSlug ? await getUserBySlug(loggedSlug) : null;
+          const loggedToken = await fetch('/data/logged-in.json').then(r => r.json());
+          const user = loggedToken ? await getUserByToken(loggedToken) : null;
           LoadMainModule('profile', user ? { user } : {});
         } catch {
           LoadMainModule('profile');

--- a/data/users/john-viking.json
+++ b/data/users/john-viking.json
@@ -12,6 +12,13 @@
     "images/ui/gift.png",
     "images/ui/follow.png"
   ],
+  "badges": [
+    "images/badges/admin.png",
+    "images/badges/artist.png",
+    "images/badges/mod.png",
+    "images/badges/vip.png",
+    "images/badges/clipper.png"
+  ],
   "subscribed": ["marina-valentine", "neko-bebop"],
   "followed": ["neko-bebop", "nick-grissom", "sarah-diamond"]
 }

--- a/data/users/john-viking.json
+++ b/data/users/john-viking.json
@@ -46,7 +46,48 @@
   },
   "hosting": null,
   "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
-  "earned-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "earned-badges": [
+    {
+      "id": "admin",
+      "icon": "images/badges/admin.png",
+      "name": "Admin",
+      "description": "Server administrator",
+      "awardedFor": "NOIZ",
+      "awardedOn": "Jan 14, 2019"
+    },
+    {
+      "id": "artist",
+      "icon": "images/badges/artist.png",
+      "name": "Artist",
+      "description": "Shared five original artworks",
+      "awardedFor": "NOIZ Summer Event",
+      "awardedOn": "Mar 26, 2019"
+    },
+    {
+      "id": "mod",
+      "icon": "images/badges/mod.png",
+      "name": "Moderator",
+      "description": "Keeps the community in check",
+      "awardedFor": "NOIZ",
+      "awardedOn": "May 2, 2018"
+    },
+    {
+      "id": "vip",
+      "icon": "images/badges/vip.png",
+      "name": "VIP",
+      "description": "Recognized supporter",
+      "awardedFor": "DbD Campaign 2025",
+      "awardedOn": "Jan 9, 2018"
+    },
+    {
+      "id": "clipper",
+      "icon": "images/badges/clipper.png",
+      "name": "Clipper",
+      "description": "Shared 100+ clips",
+      "awardedFor": "NOIZ",
+      "awardedOn": "Feb 1, 2019"
+    }
+  ],
   "BadgeID": "founder",
   "VODs": true,
   "extensions": { "enabled": [], "disabled": [] },

--- a/data/users/john-viking.json
+++ b/data/users/john-viking.json
@@ -14,6 +14,18 @@
     "images/ui/gift.png",
     "images/ui/follow.png"
   ],
+  "topics": [
+    {
+      "id": "11111111-1111-1111-1111-111111111111",
+      "name": "Raids",
+      "permissions": ["viewer"]
+    },
+    {
+      "id": "22222222-2222-2222-2222-222222222222",
+      "name": "Speedruns",
+      "permissions": ["sub", "mod"]
+    }
+  ],
   "badges": [
     "images/badges/admin.png",
     "images/badges/artist.png",

--- a/data/users/john-viking.json
+++ b/data/users/john-viking.json
@@ -6,6 +6,12 @@
   "hasNotification": false,
   "accent": "#72ffb6",
   "slug": "john-viking",
+  "about": "Leader of the NOIZ raid party and digital explorer.",
+  "memberSince": "March 2023",
+  "connections": [
+    "images/ui/gift.png",
+    "images/ui/follow.png"
+  ],
   "subscribed": ["marina-valentine", "neko-bebop"],
   "followed": ["neko-bebop", "nick-grissom", "sarah-diamond"]
 }

--- a/data/users/john-viking.json
+++ b/data/users/john-viking.json
@@ -44,7 +44,14 @@
     "away": null,
     "dnd": null
   },
-  "hosting": null,
+  "hosting": {
+    "id": "host123",
+    "title": "Raid Night",
+    "category": 42,
+    "audience": "everyone",
+    "costream": null,
+    "thumbnailId": "images/thumbs/catcafe.jpg"
+  },
   "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
   "earned-badges": [
     {

--- a/data/users/john-viking.json
+++ b/data/users/john-viking.json
@@ -33,10 +33,10 @@
     "images/badges/vip.png",
     "images/badges/clipper.png"
   ],
-  "following": [3, 4, 5],
-  "followers": [2, 3],
-  "subscribedTo": [2, 3],
-  "subscribers": [3],
+  "following": ["neko-bebop", "nick-grissom", "sarah-diamond"],
+  "followers": ["marina-valentine", "neko-bebop"],
+  "subscribedTo": ["marina-valentine", "neko-bebop"],
+  "subscribers": ["neko-bebop"],
   "lang": "en",
   "status": {
     "streaming": null,

--- a/data/users/john-viking.json
+++ b/data/users/john-viking.json
@@ -1,13 +1,15 @@
 {
+  "id": 1,
+  "token": "john-viking",
   "name": "John Viking",
   "avatar": "https://odindesignthemes.com/vikinger/img/avatar/05.jpg",
   "frame": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/decorations/afternoon_breeze.png",
   "banner": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/nameplates/cat_beans.png",
   "hasNotification": false,
   "accent": "#72ffb6",
-  "slug": "john-viking",
-  "about": "Leader of the NOIZ raid party and digital explorer.",
+  "bio": "Leader of the NOIZ raid party and digital explorer.",
   "memberSince": "March 2023",
+  "streaming": false,
   "connections": [
     "images/ui/gift.png",
     "images/ui/follow.png"
@@ -19,6 +21,22 @@
     "images/badges/vip.png",
     "images/badges/clipper.png"
   ],
-  "subscribed": ["marina-valentine", "neko-bebop"],
-  "followed": ["neko-bebop", "nick-grissom", "sarah-diamond"]
+  "following": [3, 4, 5],
+  "followers": [2, 3],
+  "subscribedTo": [2, 3],
+  "subscribers": [3],
+  "lang": "en",
+  "status": {
+    "streaming": null,
+    "online": { "watching": "home feed" },
+    "away": null,
+    "dnd": null
+  },
+  "hosting": null,
+  "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "earned-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "BadgeID": "founder",
+  "VODs": true,
+  "extensions": { "enabled": [], "disabled": [] },
+  "plugins": { "enabled": [], "disabled": [] }
 }

--- a/data/users/marina-valentine.json
+++ b/data/users/marina-valentine.json
@@ -14,6 +14,18 @@
     "images/ui/emote.png",
     "images/ui/follow.png"
   ],
+  "topics": [
+    {
+      "id": "33333333-3333-3333-3333-333333333333",
+      "name": "Cosplay",
+      "permissions": ["viewer"]
+    },
+    {
+      "id": "44444444-4444-4444-4444-444444444444",
+      "name": "Commissions",
+      "permissions": ["sub"]
+    }
+  ],
   "badges": [
     "images/badges/admin.png",
     "images/badges/artist.png",

--- a/data/users/marina-valentine.json
+++ b/data/users/marina-valentine.json
@@ -33,10 +33,10 @@
     "images/badges/vip.png",
     "images/badges/clipper.png"
   ],
-  "following": [1, 3],
-  "followers": [1],
-  "subscribedTo": [1],
-  "subscribers": [1, 3],
+  "following": ["john-viking", "neko-bebop"],
+  "followers": ["john-viking"],
+  "subscribedTo": ["john-viking"],
+  "subscribers": ["john-viking", "neko-bebop"],
   "lang": "en",
   "status": {
     "streaming": null,

--- a/data/users/marina-valentine.json
+++ b/data/users/marina-valentine.json
@@ -11,5 +11,12 @@
   "connections": [
     "images/ui/emote.png",
     "images/ui/follow.png"
+  ],
+  "badges": [
+    "images/badges/admin.png",
+    "images/badges/artist.png",
+    "images/badges/mod.png",
+    "images/badges/vip.png",
+    "images/badges/clipper.png"
   ]
 }

--- a/data/users/marina-valentine.json
+++ b/data/users/marina-valentine.json
@@ -1,13 +1,15 @@
 {
+  "id": 2,
+  "token": "marina-valentine",
   "name": "Marina Valentine",
   "avatar": "https://odindesignthemes.com/vikinger/img/avatar/01.jpg",
   "frame": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/decorations/28_years_later.png",
   "banner": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/nameplates/angels.png",
   "hasNotification": true,
   "accent": "#ff72b6",
-  "slug": "marina-valentine",
-  "about": "Streaming artist mixing beats with NOIZ blood.",
+  "bio": "Streaming artist mixing beats with NOIZ blood.",
   "memberSince": "January 2024",
+  "streaming": false,
   "connections": [
     "images/ui/emote.png",
     "images/ui/follow.png"
@@ -18,5 +20,23 @@
     "images/badges/mod.png",
     "images/badges/vip.png",
     "images/badges/clipper.png"
-  ]
+  ],
+  "following": [1, 3],
+  "followers": [1],
+  "subscribedTo": [1],
+  "subscribers": [1, 3],
+  "lang": "en",
+  "status": {
+    "streaming": null,
+    "online": { "watching": "art tutorials" },
+    "away": null,
+    "dnd": null
+  },
+  "hosting": null,
+  "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "earned-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "BadgeID": "artist",
+  "VODs": true,
+  "extensions": { "enabled": [], "disabled": [] },
+  "plugins": { "enabled": [], "disabled": [] }
 }

--- a/data/users/marina-valentine.json
+++ b/data/users/marina-valentine.json
@@ -5,5 +5,11 @@
   "banner": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/nameplates/angels.png",
   "hasNotification": true,
   "accent": "#ff72b6",
-  "slug": "marina-valentine"
+  "slug": "marina-valentine",
+  "about": "Streaming artist mixing beats with NOIZ blood.",
+  "memberSince": "January 2024",
+  "connections": [
+    "images/ui/emote.png",
+    "images/ui/follow.png"
+  ]
 }

--- a/data/users/marina-valentine.json
+++ b/data/users/marina-valentine.json
@@ -46,7 +46,48 @@
   },
   "hosting": null,
   "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
-  "earned-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "earned-badges": [
+    {
+      "id": "admin",
+      "icon": "images/badges/admin.png",
+      "name": "Admin",
+      "description": "Server administrator",
+      "awardedFor": "NOIZ",
+      "awardedOn": "Jan 14, 2019"
+    },
+    {
+      "id": "artist",
+      "icon": "images/badges/artist.png",
+      "name": "Artist",
+      "description": "Shared five original artworks",
+      "awardedFor": "NOIZ Summer Event",
+      "awardedOn": "Mar 26, 2019"
+    },
+    {
+      "id": "mod",
+      "icon": "images/badges/mod.png",
+      "name": "Moderator",
+      "description": "Keeps the community in check",
+      "awardedFor": "NOIZ",
+      "awardedOn": "May 2, 2018"
+    },
+    {
+      "id": "vip",
+      "icon": "images/badges/vip.png",
+      "name": "VIP",
+      "description": "Recognized supporter",
+      "awardedFor": "DbD Campaign 2025",
+      "awardedOn": "Jan 9, 2018"
+    },
+    {
+      "id": "clipper",
+      "icon": "images/badges/clipper.png",
+      "name": "Clipper",
+      "description": "Shared 100+ clips",
+      "awardedFor": "NOIZ",
+      "awardedOn": "Feb 1, 2019"
+    }
+  ],
   "BadgeID": "artist",
   "VODs": true,
   "extensions": { "enabled": [], "disabled": [] },

--- a/data/users/neko-bebop.json
+++ b/data/users/neko-bebop.json
@@ -5,5 +5,11 @@
   "banner": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/nameplates/aurora.png",
   "hasNotification": false,
   "accent": "#8ab4ff",
-  "slug": "neko-bebop"
+  "slug": "neko-bebop",
+  "about": "Cat cafe owner by day, NOIZ mod by night.",
+  "memberSince": "July 2022",
+  "connections": [
+    "images/ui/follow.png",
+    "images/ui/gift.png"
+  ]
 }

--- a/data/users/neko-bebop.json
+++ b/data/users/neko-bebop.json
@@ -1,12 +1,13 @@
 {
+  "id": 3,
+  "token": "neko-bebop",
   "name": "Neko Bebop",
   "avatar": "https://odindesignthemes.com/vikinger/img/avatar/02.jpg",
   "frame": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/decorations/a_duck.png",
   "banner": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/nameplates/aurora.png",
   "hasNotification": false,
   "accent": "#8ab4ff",
-  "slug": "neko-bebop",
-  "about": "Cat cafe owner by day, NOIZ mod by night.",
+  "bio": "Cat cafe owner by day, NOIZ mod by night.",
   "memberSince": "July 2022",
   "streaming": true,
   "connections": [
@@ -19,5 +20,33 @@
     "images/badges/mod.png",
     "images/badges/vip.png",
     "images/badges/clipper.png"
-  ]
+  ],
+  "following": [1, 2],
+  "followers": [1, 2, 4],
+  "subscribedTo": [1],
+  "subscribers": [1, 2],
+  "lang": "en",
+  "status": {
+    "streaming": {
+      "id": "stream123",
+      "title": "Chill Cat Café",
+      "viewers": 220,
+      "weavers": 180,
+      "category": 42,
+      "audience": "everyone",
+      "costream": null,
+      "thumbnailId": "images/thumbs/catcafe.jpg",
+      "transcodes": []
+    },
+    "online": null,
+    "away": null,
+    "dnd": null
+  },
+  "hosting": null,
+  "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "earned-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "BadgeID": "mod",
+  "VODs": true,
+  "extensions": { "enabled": [], "disabled": [] },
+  "plugins": { "enabled": [], "disabled": [] }
 }

--- a/data/users/neko-bebop.json
+++ b/data/users/neko-bebop.json
@@ -56,7 +56,48 @@
   },
   "hosting": null,
   "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
-  "earned-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "earned-badges": [
+    {
+      "id": "admin",
+      "icon": "images/badges/admin.png",
+      "name": "Admin",
+      "description": "Server administrator",
+      "awardedFor": "NOIZ",
+      "awardedOn": "Jan 14, 2019"
+    },
+    {
+      "id": "artist",
+      "icon": "images/badges/artist.png",
+      "name": "Artist",
+      "description": "Shared five original artworks",
+      "awardedFor": "NOIZ Summer Event",
+      "awardedOn": "Mar 26, 2019"
+    },
+    {
+      "id": "mod",
+      "icon": "images/badges/mod.png",
+      "name": "Moderator",
+      "description": "Keeps the community in check",
+      "awardedFor": "NOIZ",
+      "awardedOn": "May 2, 2018"
+    },
+    {
+      "id": "vip",
+      "icon": "images/badges/vip.png",
+      "name": "VIP",
+      "description": "Recognized supporter",
+      "awardedFor": "DbD Campaign 2025",
+      "awardedOn": "Jan 9, 2018"
+    },
+    {
+      "id": "clipper",
+      "icon": "images/badges/clipper.png",
+      "name": "Clipper",
+      "description": "Shared 100+ clips",
+      "awardedFor": "NOIZ",
+      "awardedOn": "Feb 1, 2019"
+    }
+  ],
   "BadgeID": "mod",
   "VODs": true,
   "extensions": { "enabled": [], "disabled": [] },

--- a/data/users/neko-bebop.json
+++ b/data/users/neko-bebop.json
@@ -8,6 +8,7 @@
   "slug": "neko-bebop",
   "about": "Cat cafe owner by day, NOIZ mod by night.",
   "memberSince": "July 2022",
+  "streaming": true,
   "connections": [
     "images/ui/follow.png",
     "images/ui/gift.png"

--- a/data/users/neko-bebop.json
+++ b/data/users/neko-bebop.json
@@ -14,6 +14,18 @@
     "images/ui/follow.png",
     "images/ui/gift.png"
   ],
+  "topics": [
+    {
+      "id": "55555555-5555-5555-5555-555555555555",
+      "name": "Music",
+      "permissions": ["viewer", "sub"]
+    },
+    {
+      "id": "66666666-6666-6666-6666-666666666666",
+      "name": "Cat Pics",
+      "permissions": []
+    }
+  ],
   "badges": [
     "images/badges/admin.png",
     "images/badges/artist.png",

--- a/data/users/neko-bebop.json
+++ b/data/users/neko-bebop.json
@@ -33,10 +33,10 @@
     "images/badges/vip.png",
     "images/badges/clipper.png"
   ],
-  "following": [1, 2],
-  "followers": [1, 2, 4],
-  "subscribedTo": [1],
-  "subscribers": [1, 2],
+  "following": ["john-viking", "marina-valentine"],
+  "followers": ["john-viking", "marina-valentine", "nick-grissom"],
+  "subscribedTo": ["john-viking"],
+  "subscribers": ["john-viking", "marina-valentine"],
   "lang": "en",
   "status": {
     "streaming": {

--- a/data/users/neko-bebop.json
+++ b/data/users/neko-bebop.json
@@ -12,5 +12,12 @@
   "connections": [
     "images/ui/follow.png",
     "images/ui/gift.png"
+  ],
+  "badges": [
+    "images/badges/admin.png",
+    "images/badges/artist.png",
+    "images/badges/mod.png",
+    "images/badges/vip.png",
+    "images/badges/clipper.png"
   ]
 }

--- a/data/users/nick-grissom.json
+++ b/data/users/nick-grissom.json
@@ -33,10 +33,10 @@
     "images/badges/vip.png",
     "images/badges/clipper.png"
   ],
-  "following": [1, 3],
-  "followers": [1, 5],
+  "following": ["john-viking", "neko-bebop"],
+  "followers": ["john-viking", "sarah-diamond"],
   "subscribedTo": [],
-  "subscribers": [1],
+  "subscribers": ["john-viking"],
   "lang": "en",
   "status": {
     "streaming": null,

--- a/data/users/nick-grissom.json
+++ b/data/users/nick-grissom.json
@@ -1,13 +1,15 @@
 {
+  "id": 4,
+  "token": "nick-grissom",
   "name": "Nick Grissom",
   "avatar": "https://odindesignthemes.com/vikinger/img/avatar/03.jpg",
   "frame": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/decorations/a_hint_of_clove.png",
   "banner": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/nameplates/black_mana.png",
   "hasNotification": false,
   "accent": "#ffd059",
-  "slug": "nick-grissom",
-  "about": "Speedrunner chasing the highest NOIZ scores.",
+  "bio": "Speedrunner chasing the highest NOIZ scores.",
   "memberSince": "May 2021",
+  "streaming": false,
   "connections": [
     "images/ui/emote.png",
     "images/ui/gift.png"
@@ -18,5 +20,23 @@
     "images/badges/mod.png",
     "images/badges/vip.png",
     "images/badges/clipper.png"
-  ]
+  ],
+  "following": [1, 3],
+  "followers": [1, 5],
+  "subscribedTo": [],
+  "subscribers": [1],
+  "lang": "en",
+  "status": {
+    "streaming": null,
+    "online": { "watching": "speedrun clips" },
+    "away": null,
+    "dnd": null
+  },
+  "hosting": null,
+  "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "earned-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "BadgeID": "speedrunner",
+  "VODs": true,
+  "extensions": { "enabled": [], "disabled": [] },
+  "plugins": { "enabled": [], "disabled": [] }
 }

--- a/data/users/nick-grissom.json
+++ b/data/users/nick-grissom.json
@@ -14,6 +14,18 @@
     "images/ui/emote.png",
     "images/ui/gift.png"
   ],
+  "topics": [
+    {
+      "id": "77777777-7777-7777-7777-777777777777",
+      "name": "Game Dev",
+      "permissions": ["viewer"]
+    },
+    {
+      "id": "88888888-8888-8888-8888-888888888888",
+      "name": "Bug Reports",
+      "permissions": ["mod"]
+    }
+  ],
   "badges": [
     "images/badges/admin.png",
     "images/badges/artist.png",

--- a/data/users/nick-grissom.json
+++ b/data/users/nick-grissom.json
@@ -5,5 +5,11 @@
   "banner": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/nameplates/black_mana.png",
   "hasNotification": false,
   "accent": "#ffd059",
-  "slug": "nick-grissom"
+  "slug": "nick-grissom",
+  "about": "Speedrunner chasing the highest NOIZ scores.",
+  "memberSince": "May 2021",
+  "connections": [
+    "images/ui/emote.png",
+    "images/ui/gift.png"
+  ]
 }

--- a/data/users/nick-grissom.json
+++ b/data/users/nick-grissom.json
@@ -46,7 +46,48 @@
   },
   "hosting": null,
   "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
-  "earned-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "earned-badges": [
+    {
+      "id": "admin",
+      "icon": "images/badges/admin.png",
+      "name": "Admin",
+      "description": "Server administrator",
+      "awardedFor": "NOIZ",
+      "awardedOn": "Jan 14, 2019"
+    },
+    {
+      "id": "artist",
+      "icon": "images/badges/artist.png",
+      "name": "Artist",
+      "description": "Shared five original artworks",
+      "awardedFor": "NOIZ Summer Event",
+      "awardedOn": "Mar 26, 2019"
+    },
+    {
+      "id": "mod",
+      "icon": "images/badges/mod.png",
+      "name": "Moderator",
+      "description": "Keeps the community in check",
+      "awardedFor": "NOIZ",
+      "awardedOn": "May 2, 2018"
+    },
+    {
+      "id": "vip",
+      "icon": "images/badges/vip.png",
+      "name": "VIP",
+      "description": "Recognized supporter",
+      "awardedFor": "DbD Campaign 2025",
+      "awardedOn": "Jan 9, 2018"
+    },
+    {
+      "id": "clipper",
+      "icon": "images/badges/clipper.png",
+      "name": "Clipper",
+      "description": "Shared 100+ clips",
+      "awardedFor": "NOIZ",
+      "awardedOn": "Feb 1, 2019"
+    }
+  ],
   "BadgeID": "speedrunner",
   "VODs": true,
   "extensions": { "enabled": [], "disabled": [] },

--- a/data/users/nick-grissom.json
+++ b/data/users/nick-grissom.json
@@ -11,5 +11,12 @@
   "connections": [
     "images/ui/emote.png",
     "images/ui/gift.png"
+  ],
+  "badges": [
+    "images/badges/admin.png",
+    "images/badges/artist.png",
+    "images/badges/mod.png",
+    "images/badges/vip.png",
+    "images/badges/clipper.png"
   ]
 }

--- a/data/users/sarah-diamond.json
+++ b/data/users/sarah-diamond.json
@@ -11,5 +11,12 @@
   "connections": [
     "images/ui/follow.png",
     "images/ui/emote.png"
+  ],
+  "badges": [
+    "images/badges/admin.png",
+    "images/badges/artist.png",
+    "images/badges/mod.png",
+    "images/badges/vip.png",
+    "images/badges/clipper.png"
   ]
 }

--- a/data/users/sarah-diamond.json
+++ b/data/users/sarah-diamond.json
@@ -1,13 +1,15 @@
 {
+  "id": 5,
+  "token": "sarah-diamond",
   "name": "Sarah Diamond",
   "avatar": "https://odindesignthemes.com/vikinger/img/avatar/04.jpg",
   "frame": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/decorations/aespa_fanlight.png",
   "banner": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/nameplates/blue_mana.png",
   "hasNotification": false,
   "accent": "#b06dff",
-  "slug": "sarah-diamond",
-  "about": "Cosplayer weaving NOIZ magic on stream.",
+  "bio": "Cosplayer weaving NOIZ magic on stream.",
   "memberSince": "September 2020",
+  "streaming": false,
   "connections": [
     "images/ui/follow.png",
     "images/ui/emote.png"
@@ -18,5 +20,23 @@
     "images/badges/mod.png",
     "images/badges/vip.png",
     "images/badges/clipper.png"
-  ]
+  ],
+  "following": [1, 2],
+  "followers": [1, 3],
+  "subscribedTo": [2],
+  "subscribers": [1],
+  "lang": "en",
+  "status": {
+    "streaming": null,
+    "online": { "watching": "cosplay how-tos" },
+    "away": null,
+    "dnd": null
+  },
+  "hosting": null,
+  "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "earned-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "BadgeID": "cosplayer",
+  "VODs": true,
+  "extensions": { "enabled": [], "disabled": [] },
+  "plugins": { "enabled": [], "disabled": [] }
 }

--- a/data/users/sarah-diamond.json
+++ b/data/users/sarah-diamond.json
@@ -33,10 +33,10 @@
     "images/badges/vip.png",
     "images/badges/clipper.png"
   ],
-  "following": [1, 2],
-  "followers": [1, 3],
-  "subscribedTo": [2],
-  "subscribers": [1],
+  "following": ["john-viking", "marina-valentine"],
+  "followers": ["john-viking", "neko-bebop"],
+  "subscribedTo": ["marina-valentine"],
+  "subscribers": ["john-viking"],
   "lang": "en",
   "status": {
     "streaming": null,

--- a/data/users/sarah-diamond.json
+++ b/data/users/sarah-diamond.json
@@ -14,6 +14,18 @@
     "images/ui/follow.png",
     "images/ui/emote.png"
   ],
+  "topics": [
+    {
+      "id": "99999999-9999-9999-9999-999999999999",
+      "name": "Photography",
+      "permissions": ["viewer"]
+    },
+    {
+      "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      "name": "Travel Vlogs",
+      "permissions": ["sub"]
+    }
+  ],
   "badges": [
     "images/badges/admin.png",
     "images/badges/artist.png",

--- a/data/users/sarah-diamond.json
+++ b/data/users/sarah-diamond.json
@@ -46,7 +46,48 @@
   },
   "hosting": null,
   "set-badges": ["admin", "artist", "mod", "vip", "clipper"],
-  "earned-badges": ["admin", "artist", "mod", "vip", "clipper"],
+  "earned-badges": [
+    {
+      "id": "admin",
+      "icon": "images/badges/admin.png",
+      "name": "Admin",
+      "description": "Server administrator",
+      "awardedFor": "NOIZ",
+      "awardedOn": "Jan 14, 2019"
+    },
+    {
+      "id": "artist",
+      "icon": "images/badges/artist.png",
+      "name": "Artist",
+      "description": "Shared five original artworks",
+      "awardedFor": "NOIZ Summer Event",
+      "awardedOn": "Mar 26, 2019"
+    },
+    {
+      "id": "mod",
+      "icon": "images/badges/mod.png",
+      "name": "Moderator",
+      "description": "Keeps the community in check",
+      "awardedFor": "NOIZ",
+      "awardedOn": "May 2, 2018"
+    },
+    {
+      "id": "vip",
+      "icon": "images/badges/vip.png",
+      "name": "VIP",
+      "description": "Recognized supporter",
+      "awardedFor": "DbD Campaign 2025",
+      "awardedOn": "Jan 9, 2018"
+    },
+    {
+      "id": "clipper",
+      "icon": "images/badges/clipper.png",
+      "name": "Clipper",
+      "description": "Shared 100+ clips",
+      "awardedFor": "NOIZ",
+      "awardedOn": "Feb 1, 2019"
+    }
+  ],
   "BadgeID": "cosplayer",
   "VODs": true,
   "extensions": { "enabled": [], "disabled": [] },

--- a/data/users/sarah-diamond.json
+++ b/data/users/sarah-diamond.json
@@ -5,5 +5,11 @@
   "banner": "https://cdn.jsdelivr.net/gh/itspi3141/discord-fake-avatar-decorations@main/public/nameplates/blue_mana.png",
   "hasNotification": false,
   "accent": "#b06dff",
-  "slug": "sarah-diamond"
+  "slug": "sarah-diamond",
+  "about": "Cosplayer weaving NOIZ magic on stream.",
+  "memberSince": "September 2020",
+  "connections": [
+    "images/ui/follow.png",
+    "images/ui/emote.png"
+  ]
 }

--- a/index.html
+++ b/index.html
@@ -16,7 +16,9 @@
   <!-- Header module -->
   <module data-module="header" data-css="true"></module>
 
-  <main class="content-grid" style="transform: translate(200.5px); transition: transform 0.4s ease-in-out;"></main>
+  <main class="content-grid" style="position: relative; transform: translate(200.5px); transition: transform 0.4s ease-in-out;">
+    <module data-module="profile-overlay" data-css="true"></module>
+  </main>
 
   <!-- User rail module -->
   <module data-module="chat" data-css="true"></module>

--- a/index.html
+++ b/index.html
@@ -16,9 +16,9 @@
   <!-- Header module -->
   <module data-module="header" data-css="true"></module>
 
-  <main class="content-grid" style="position: relative; transform: translate(200.5px); transition: transform 0.4s ease-in-out;">
-    <module data-module="profile-overlay" data-css="true"></module>
-  </main>
+  <main class="content-grid" style="position: relative; transform: translate(200.5px); transition: transform 0.4s ease-in-out;"></main>
+
+  <module data-module="profile-overlay" data-css="true"></module>
 
   <!-- User rail module -->
   <module data-module="chat" data-css="true"></module>

--- a/index.html
+++ b/index.html
@@ -22,9 +22,12 @@
   <module data-module="chat" data-css="true"></module>
   <module data-module="user-rail" data-css="true" class="d-none d-lg-flex"></module>
 
-  <!-- Sidebar chat module 
+  <!-- Sidebar chat module
   <module data-module="chat-sidebar" data-css="true" class="d-none d-lg-flex"></module>
   -->
+
+  <!-- Mini profile overlay -->
+  <module data-module="mini-profile" data-css="true"></module>
 
   <!-- SVG sprite mount -->
   <module data-module="svgs"></module>

--- a/module/chat/chat.js
+++ b/module/chat/chat.js
@@ -1,10 +1,10 @@
 // module/chat/chat.js
 // Simple sidebar chat module with mock data and basic send capability
 
-import { getUserBySlug } from '../users.js';
+import { getUserByToken } from '../users.js';
 
 const profileData = (u = {}) =>
-  `data-profile-name="${u.name || ''}" data-profile-slug="${u.slug || ''}" data-profile-avatar="${u.avatar || ''}" data-profile-banner="${u.banner || ''}" data-profile-accent="${u.accent || ''}" data-profile-frame="${u.frame || ''}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-badges="${(u.badges || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}"`;
+  `data-profile-name="${u.name || ''}" data-profile-token="${u.token || ''}" data-profile-avatar="${u.avatar || ''}" data-profile-banner="${u.banner || ''}" data-profile-accent="${u.accent || ''}" data-profile-frame="${u.frame || ''}" data-profile-bio="${u.bio || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-badges="${(u.badges || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}"`;
 
 const messageTpl = (m) => {
   const u = m.user || {};
@@ -227,8 +227,8 @@ const tpl = (messages) => `
 `;
 
 export default async function init({ root, utils }) {
-  const slugs = ['john-viking', 'marina-valentine', 'neko-bebop', 'nick-grissom', 'sarah-diamond'];
-  const users = Object.fromEntries(await Promise.all(slugs.map(async (s) => [s, await getUserBySlug(s)])));
+  const tokens = ['john-viking', 'marina-valentine', 'neko-bebop', 'nick-grissom', 'sarah-diamond'];
+  const users = Object.fromEntries(await Promise.all(tokens.map(async (s) => [s, await getUserByToken(s)])));
 
   let messages = [
     {
@@ -306,7 +306,7 @@ export default async function init({ root, utils }) {
     if (!text) return;
     messages.push({
       time: new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }),
-      user: { name: 'Anon', slug: 'anon', accent: '#333' },
+      user: { name: 'Anon', token: 'anon', accent: '#333' },
       color: '#333',
       text
     });
@@ -361,7 +361,7 @@ export default async function init({ root, utils }) {
     if (!selectedResonance) return;
       messages.push({
         time: new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }),
-        user: { name: 'Anon', slug: 'anon', accent: '#333' },
+        user: { name: 'Anon', token: 'anon', accent: '#333' },
         type: 'sticker',
         sticker: selectedResonance.sticker,
         amount: selectedResonance.amount,

--- a/module/chat/chat.js
+++ b/module/chat/chat.js
@@ -4,7 +4,7 @@
 import { getUserBySlug } from '../users.js';
 
 const profileData = (u = {}) =>
-  `data-profile-name="${u.name || ''}" data-profile-slug="${u.slug || ''}" data-profile-avatar="${u.avatar || ''}" data-profile-banner="${u.banner || ''}" data-profile-accent="${u.accent || ''}" data-profile-frame="${u.frame || ''}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}"`;
+  `data-profile-name="${u.name || ''}" data-profile-slug="${u.slug || ''}" data-profile-avatar="${u.avatar || ''}" data-profile-banner="${u.banner || ''}" data-profile-accent="${u.accent || ''}" data-profile-frame="${u.frame || ''}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}"`;
 
 const messageTpl = (m) => {
   const u = m.user || {};

--- a/module/chat/chat.js
+++ b/module/chat/chat.js
@@ -1,12 +1,18 @@
 // module/chat/chat.js
 // Simple sidebar chat module with mock data and basic send capability
 
+import { getUserBySlug } from '../users.js';
+
+const profileData = (u = {}) =>
+  `data-profile-name="${u.name || ''}" data-profile-slug="${u.slug || ''}" data-profile-avatar="${u.avatar || ''}" data-profile-banner="${u.banner || ''}" data-profile-accent="${u.accent || ''}" data-profile-frame="${u.frame || ''}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}"`;
+
 const messageTpl = (m) => {
+  const u = m.user || {};
   if (m.type === 'donation') {
     return `
       <div class="chat-donation">
         <div class="donation-header">
-          <span class="name">${m.user}</span>
+          <span class="name" ${profileData(u)}>${u.name || ''}</span>
           <span class="amount">${m.amount}</span>
         </div>
         ${m.text ? `<div class="donation-text">${m.text}</div>` : ''}
@@ -16,12 +22,12 @@ const messageTpl = (m) => {
   if (m.type === 'sticker') {
     return `
       <div class="chat-message sticker">
-        <span class="msg-avatar avatar-wrap" data-profile-name="${m.user}" data-profile-avatar="${m.avatar || ''}">
-          ${m.avatar ? `<img class="avatar-image" src="${m.avatar}" alt="${m.user}">` : `<span class="avatar-letter" style="background:${m.avatarColor || '#933'}">${(m.user || '?')[0]}</span>`}
+        <span class="msg-avatar avatar-wrap" ${profileData(u)}>
+          ${u.avatar ? `<img class="avatar-image" src="${u.avatar}" alt="${u.name || ''}">` : `<span class="avatar-letter" style="background:${u.accent || '#933'}">${(u.name || '?')[0]}</span>`}
         </span>
         <div class="msg-body">
         <div class="msg-header">
-          <span class="name" style="color:${m.color || '#333'}" data-profile-name="${m.user}" data-profile-avatar="${m.avatar || ''}">${m.user}</span>
+          <span class="name" style="color:${m.color || u.accent || '#333'}" ${profileData(u)}>${u.name || ''}</span>
           <span class="time">${m.time}</span>
         </div>
           <div class="sticker-meta">
@@ -35,13 +41,13 @@ const messageTpl = (m) => {
   }
   return `
       <div class="chat-message">
-        <span class="msg-avatar avatar-wrap" data-profile-name="${m.user}" data-profile-avatar="${m.avatar || ''}">
-          ${m.avatar ? `<img class="avatar-image" src="${m.avatar}" alt="${m.user}">` : `<span class="avatar-letter" style="background:${m.avatarColor || '#933'}">${(m.user || '?')[0]}</span>`}
+        <span class="msg-avatar avatar-wrap" ${profileData(u)}>
+          ${u.avatar ? `<img class="avatar-image" src="${u.avatar}" alt="${u.name || ''}">` : `<span class="avatar-letter" style="background:${u.accent || '#933'}">${(u.name || '?')[0]}</span>`}
         </span>
         <div class="msg-body">
           <div class="msg-header">
             <div class="user-meta">
-              <span class="name" style="color:${m.color || '#333'}" data-profile-name="${m.user}" data-profile-avatar="${m.avatar || ''}">${m.user}</span>
+              <span class="name" style="color:${m.color || u.accent || '#333'}" ${profileData(u)}>${u.name || ''}</span>
               ${m.badges && m.badges.length ? `<span class="badges">${m.badges.slice(0,5).map((b) => `<img src="${b}" alt="badge" />`).join('')}</span>` : ''}
             </div>
             <span class="time">${m.time}</span>
@@ -221,57 +227,60 @@ const tpl = (messages) => `
 `;
 
 export default async function init({ root, utils }) {
+  const slugs = ['john-viking', 'marina-valentine', 'neko-bebop', 'nick-grissom', 'sarah-diamond'];
+  const users = Object.fromEntries(await Promise.all(slugs.map(async (s) => [s, await getUserBySlug(s)])));
+
   let messages = [
     {
       time: '9:58 AM',
-      user: 'Lena',
-      avatar: 'images/logo.png',
+      user: users['john-viking'],
       color: '#07b',
       text: 'wow',
       badges: [BADGE_URLS[0], BADGE_URLS[1], BADGE_URLS[2], BADGE_URLS[3], BADGE_URLS[4]]
     },
     {
       time: '9:58 AM',
-      user: 'Ash',
-      avatar: 'images/logo.png',
+      user: users['marina-valentine'],
       color: '#0a0',
       text: 'more pushups!',
       badges: [BADGE_URLS[5], BADGE_URLS[6]]
     },
     {
       time: '9:58 AM',
-      user: 'IntroMeb',
-      avatar: 'images/logo.png',
+      user: users['neko-bebop'],
       color: '#c00',
       text: 'great play!',
       badges: [BADGE_URLS[7]]
     },
     {
       time: '9:58 AM',
-      user: 'Chankonabe',
-      avatar: 'images/logo.png',
+      user: users['nick-grissom'],
       color: '#b80',
       text: "how's everyone on the eh team doing?",
       badges: [BADGE_URLS[8], BADGE_URLS[9], BADGE_URLS[10]]
     },
     {
       time: '9:58 AM',
-      user: 'pexelwiz',
-      avatar: 'images/logo.png',
+      user: users['sarah-diamond'],
       color: '#609',
       text: 'awesome! 👏'
     },
     {
       time: '9:59 AM',
-      user: 'StickerFan',
-      avatar: 'images/logo.png',
+      user: users['neko-bebop'],
       color: '#333',
       type: 'sticker',
       sticker: 'images/resonances/001/catch_em.gif',
       amount: '100',
       badge: BADGE_URLS[11]
     },
-    { type: 'donation', user: 'Laura Ipsum', amount: '$5.00', text: 'BRAVO 🦊' }
+    {
+      type: 'donation',
+      time: '9:59 AM',
+      user: users['marina-valentine'],
+      amount: '$5.00',
+      text: 'BRAVO 🦊'
+    }
   ];
 
   let donoScroller, emoteDrawer, resonanceDrawer, resonanceUseDrawer;
@@ -297,7 +306,7 @@ export default async function init({ root, utils }) {
     if (!text) return;
     messages.push({
       time: new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }),
-      user: 'Anon',
+      user: { name: 'Anon', slug: 'anon', accent: '#333' },
       color: '#333',
       text
     });
@@ -350,14 +359,14 @@ export default async function init({ root, utils }) {
 
   utils.delegate(root, 'click', '.resonance-use-btn', () => {
     if (!selectedResonance) return;
-    messages.push({
-      time: new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }),
-      user: 'Anon',
-      type: 'sticker',
-      sticker: selectedResonance.sticker,
-      amount: selectedResonance.amount,
-      badge: selectedResonance.badge
-    });
+      messages.push({
+        time: new Date().toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }),
+        user: { name: 'Anon', slug: 'anon', accent: '#333' },
+        type: 'sticker',
+        sticker: selectedResonance.sticker,
+        amount: selectedResonance.amount,
+        badge: selectedResonance.badge
+      });
     resonanceUseDrawer.classList.remove('open');
     render();
   });

--- a/module/chat/chat.js
+++ b/module/chat/chat.js
@@ -16,12 +16,12 @@ const messageTpl = (m) => {
   if (m.type === 'sticker') {
     return `
       <div class="chat-message sticker">
-        <span class="msg-avatar avatar-wrap">
+        <span class="msg-avatar avatar-wrap" data-profile-name="${m.user}" data-profile-avatar="${m.avatar || ''}">
           ${m.avatar ? `<img class="avatar-image" src="${m.avatar}" alt="${m.user}">` : `<span class="avatar-letter" style="background:${m.avatarColor || '#933'}">${(m.user || '?')[0]}</span>`}
         </span>
         <div class="msg-body">
         <div class="msg-header">
-          <span class="name" style="color:${m.color || '#333'}">${m.user}</span>
+          <span class="name" style="color:${m.color || '#333'}" data-profile-name="${m.user}" data-profile-avatar="${m.avatar || ''}">${m.user}</span>
           <span class="time">${m.time}</span>
         </div>
           <div class="sticker-meta">
@@ -34,17 +34,17 @@ const messageTpl = (m) => {
     `;
   }
   return `
-    <div class="chat-message">
-      <span class="msg-avatar avatar-wrap">
-        ${m.avatar ? `<img class="avatar-image" src="${m.avatar}" alt="${m.user}">` : `<span class="avatar-letter" style="background:${m.avatarColor || '#933'}">${(m.user || '?')[0]}</span>`}
-      </span>
-      <div class="msg-body">
-        <div class="msg-header">
-          <div class="user-meta">
-            <span class="name" style="color:${m.color || '#333'}">${m.user}</span>
-            ${m.badges && m.badges.length ? `<span class="badges">${m.badges.slice(0,5).map((b) => `<img src="${b}" alt="badge" />`).join('')}</span>` : ''}
-          </div>
-          <span class="time">${m.time}</span>
+      <div class="chat-message">
+        <span class="msg-avatar avatar-wrap" data-profile-name="${m.user}" data-profile-avatar="${m.avatar || ''}">
+          ${m.avatar ? `<img class="avatar-image" src="${m.avatar}" alt="${m.user}">` : `<span class="avatar-letter" style="background:${m.avatarColor || '#933'}">${(m.user || '?')[0]}</span>`}
+        </span>
+        <div class="msg-body">
+          <div class="msg-header">
+            <div class="user-meta">
+              <span class="name" style="color:${m.color || '#333'}" data-profile-name="${m.user}" data-profile-avatar="${m.avatar || ''}">${m.user}</span>
+              ${m.badges && m.badges.length ? `<span class="badges">${m.badges.slice(0,5).map((b) => `<img src="${b}" alt="badge" />`).join('')}</span>` : ''}
+            </div>
+            <span class="time">${m.time}</span>
         </div>
         <div class="text">${m.text}</div>
       </div>

--- a/module/chat/chat.js
+++ b/module/chat/chat.js
@@ -4,7 +4,7 @@
 import { getUserBySlug } from '../users.js';
 
 const profileData = (u = {}) =>
-  `data-profile-name="${u.name || ''}" data-profile-slug="${u.slug || ''}" data-profile-avatar="${u.avatar || ''}" data-profile-banner="${u.banner || ''}" data-profile-accent="${u.accent || ''}" data-profile-frame="${u.frame || ''}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}"`;
+  `data-profile-name="${u.name || ''}" data-profile-slug="${u.slug || ''}" data-profile-avatar="${u.avatar || ''}" data-profile-banner="${u.banner || ''}" data-profile-accent="${u.accent || ''}" data-profile-frame="${u.frame || ''}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-badges="${(u.badges || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}"`;
 
 const messageTpl = (m) => {
   const u = m.user || {};

--- a/module/header/header.js
+++ b/module/header/header.js
@@ -253,7 +253,7 @@ export default async function init({ hub, root, utils }) {
       const memberItems = members
         .map(
           (u) => `
-    <a class="dropdown-item header-search-item" href="#/profile/${u.slug}">
+    <a class="dropdown-item header-search-item" href="#/profile/${u.token}">
       <img src="${u.avatar}" alt="${u.name}">
       <div class="info">
         <div class="name">${u.name}</div>

--- a/module/header/header.service.js
+++ b/module/header/header.service.js
@@ -1,6 +1,6 @@
-import { getUserBySlug } from '../users.js';
+import { getUserByToken } from '../users.js';
 
-const SLUGS = [
+const TOKENS = [
   'john-viking',
   'marina-valentine',
   'neko-bebop',
@@ -19,9 +19,9 @@ export default async function init({ hub }) {
     const q = term?.trim().toLowerCase();
     if (!q) return { members: [], modules: [] };
     try {
-      const users = (await Promise.all(SLUGS.map(getUserBySlug))).filter(Boolean);
+      const users = (await Promise.all(TOKENS.map(getUserByToken))).filter(Boolean);
       const members = users
-        .filter((u) => u.name.toLowerCase().includes(q) || u.slug.includes(q))
+        .filter((u) => u.name.toLowerCase().includes(q) || u.token.includes(q))
         .map((u) => ({ ...u, friendCount: 0 }));
       const modules = navModules.filter((m) => m.name.toLowerCase().includes(q));
       return { members, modules };

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -108,25 +108,28 @@ module[data-module="mini-profile"] .mini-profile .mp-actions {
   margin-top: 8px;
   display: flex;
   gap: 8px;
+  width: 100%;
 }
 
 module[data-module="mini-profile"] .mini-profile .mp-action {
+  flex: 1 1 0;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   background: var(--accent, #5865f2);
   border: none;
   color: #ffffff;
-  padding: 4px 6px;
-  font-size: 0.875rem;
+  padding: 6px 4px;
+  font-size: 0.75rem;
   border-radius: 6px;
   cursor: pointer;
-  width: auto;
+  text-align: center;
 }
 
 module[data-module="mini-profile"] .mini-profile .mp-action svg {
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
 }
 
 module[data-module="mini-profile"] .mini-profile .mp-badges {

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -179,10 +179,6 @@ module[data-module="mini-profile"] .mini-profile .mp-conn-list img {
   height: 24px;
 }
 
-module[data-module="mini-profile"] .mini-profile .mp-note-text {
-  font-size: 0.875rem;
-  color: #6b7280;
-}
 
 module[data-module="mini-profile"] .mini-profile .mp-activity-list {
   display: flex;

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -27,7 +27,10 @@ module[data-module="mini-profile"] .mini-profile.hidden {
 
 module[data-module="mini-profile"] .mini-profile .mp-banner {
   height: 120px;
-  background: var(--banner, #f3f4f6) center/cover no-repeat;
+  background-color: #f3f4f6;
+  background-position: center top;
+  background-size: cover;
+  background-repeat: no-repeat;
   position: relative;
 }
 

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -2,13 +2,13 @@ module[data-module="mini-profile"] .mini-profile {
   --mp-w: 320px;
   --mp-radius: 12px;
   position: fixed;
-  z-index: 1000;
+  z-index: 2000;
   width: var(--mp-w);
-  color: #e6e6e6;
-  background: #1e1f22;
-  border: 1px solid #0e0f12;
+  color: #1f2937;
+  background: #ffffff;
+  border: 1px solid #e5e7eb;
   border-radius: var(--mp-radius);
-  box-shadow: 0 20px 40px rgba(0,0,0,.45), 0 0 0 1px rgba(255,255,255,.05) inset;
+  box-shadow: 0 20px 40px rgba(0,0,0,.1), 0 0 0 1px rgba(0,0,0,.05) inset;
   overflow: hidden;
   opacity: 0;
   transform: translateY(6px) scale(.98);
@@ -25,7 +25,7 @@ module[data-module="mini-profile"] .mini-profile.hidden {
 }
 module[data-module="mini-profile"] .mini-profile .mp-banner {
   height: 92px;
-  background: var(--banner, linear-gradient(90deg, #2f3340, #242733));
+  background: var(--banner, linear-gradient(90deg, #f0f2f5, #e5e7eb));
   background-position: center;
   background-size: cover;
   background-repeat: no-repeat;
@@ -35,7 +35,7 @@ module[data-module="mini-profile"] .mini-profile .mp-banner::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(to bottom, rgba(0,0,0,.0) 20%, rgba(0,0,0,.35) 100%);
+  background: linear-gradient(to bottom, rgba(255,255,255,.0) 20%, rgba(255,255,255,.35) 100%);
 }
 module[data-module="mini-profile"] .mini-profile .mp-accent {
   position: relative;
@@ -66,7 +66,7 @@ module[data-module="mini-profile"] .mini-profile .mp-avatar::before {
   position: absolute;
   inset: -4px;
   border-radius: 50%;
-  background: #1e1f22;
+  background: #ffffff;
   z-index: 0;
 }
 module[data-module="mini-profile"] .mini-profile .mp-avatar img {
@@ -91,7 +91,7 @@ module[data-module="mini-profile"] .mini-profile .mp-avatar::after {
 module[data-module="mini-profile"] .mini-profile .mp-display {
   font-weight: 800;
   font-size: 16px;
-  color: #fff;
+  color: #1f2937;
 }
 module[data-module="mini-profile"] .mini-profile .mp-name-line {
   display: flex;
@@ -107,18 +107,18 @@ module[data-module="mini-profile"] .mini-profile .mp-status-line {
 }
 module[data-module="mini-profile"] .mini-profile .mp-status-text {
   font-size: 12px;
-  color: #ddd;
+  color: #6b7280;
 }
 module[data-module="mini-profile"] .mini-profile .status-dot {
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #888;
+  background: #9ca3af;
 }
 module[data-module="mini-profile"] .mini-profile .status-dot[data-status="online"] { background: #3ba55d; }
 module[data-module="mini-profile"] .mini-profile .status-dot[data-status="away"] { background: #faa81a; }
 module[data-module="mini-profile"] .mini-profile .status-dot[data-status="dnd"] { background: #ed4245; }
-module[data-module="mini-profile"] .mini-profile .status-dot[data-status="offline"] { background: #5b5e66; }
+module[data-module="mini-profile"] .mini-profile .status-dot[data-status="offline"] { background: #9ca3af; }
 module[data-module="mini-profile"] .mini-profile .status-dot[data-status="live"] { background: #f50; }
 module[data-module="mini-profile"] .mini-profile .mp-actions {
   display: flex;
@@ -129,9 +129,9 @@ module[data-module="mini-profile"] .mini-profile .mp-actions {
 }
 module[data-module="mini-profile"] .mini-profile .mp-btn,
 module[data-module="mini-profile"] .mini-profile .mp-icon {
-  background: #2a2c31;
-  color: #e6e6e6;
-  border: 1px solid #1b1d22;
+  background: #f0f2f5;
+  color: #1f2937;
+  border: 1px solid #e5e7eb;
   padding: 8px 10px;
   border-radius: 8px;
   cursor: pointer;
@@ -141,7 +141,7 @@ module[data-module="mini-profile"] .mini-profile .mp-icon {
 }
 module[data-module="mini-profile"] .mini-profile .mp-btn.primary {
   background: var(--accent, #5865f2);
-  border-color: transparent;
+  border-color: var(--accent, #5865f2);
   color: #fff;
 }
 module[data-module="mini-profile"] .mini-profile .mp-btn.primary:hover {
@@ -151,9 +151,9 @@ module[data-module="mini-profile"] .mini-profile .mp-icon {
   padding: 6px 8px;
   border-radius: 8px;
   font-size: 18px;
-  color: #bbb;
+  color: #6b7280;
 }
 module[data-module="mini-profile"] .mini-profile .mp-icon:hover {
-  background: #34363c;
-  color: #fff;
+  background: #e5e7eb;
+  color: #1f2937;
 }

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -120,10 +120,6 @@ module[data-module="mini-profile"] .mini-profile .mp-action {
   cursor: pointer;
 }
 
-module[data-module="mini-profile"] .mini-profile .mp-action.icon-only {
-  padding: 6px;
-}
-
 module[data-module="mini-profile"] .mini-profile .mp-action svg {
   width: 16px;
   height: 16px;

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -1,0 +1,159 @@
+module[data-module="mini-profile"] .mini-profile {
+  --mp-w: 320px;
+  --mp-radius: 12px;
+  position: fixed;
+  z-index: 1000;
+  width: var(--mp-w);
+  color: #e6e6e6;
+  background: #1e1f22;
+  border: 1px solid #0e0f12;
+  border-radius: var(--mp-radius);
+  box-shadow: 0 20px 40px rgba(0,0,0,.45), 0 0 0 1px rgba(255,255,255,.05) inset;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(6px) scale(.98);
+  transition: opacity .14s ease, transform .14s ease;
+  pointer-events: none;
+}
+module[data-module="mini-profile"] .mini-profile.visible {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+module[data-module="mini-profile"] .mini-profile.hidden {
+  display: block;
+}
+module[data-module="mini-profile"] .mini-profile .mp-banner {
+  height: 92px;
+  background: var(--banner, linear-gradient(90deg, #2f3340, #242733));
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  position: relative;
+}
+module[data-module="mini-profile"] .mini-profile .mp-banner::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(0,0,0,.0) 20%, rgba(0,0,0,.35) 100%);
+}
+module[data-module="mini-profile"] .mini-profile .mp-accent {
+  position: relative;
+  height: 2px;
+  background: linear-gradient(90deg, var(--accent,#7c3aed), transparent 60%);
+  z-index: 2;
+}
+module[data-module="mini-profile"] .mini-profile .mp-body {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 12px;
+  padding: 12px;
+  position: relative;
+  z-index: 3;
+}
+module[data-module="mini-profile"] .mini-profile .mp-avatar {
+  position: relative;
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  overflow: visible;
+  isolation: isolate;
+  margin-top: -36px;
+  z-index: 4;
+}
+module[data-module="mini-profile"] .mini-profile .mp-avatar::before {
+  content: "";
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  background: #1e1f22;
+  z-index: 0;
+}
+module[data-module="mini-profile"] .mini-profile .mp-avatar img {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  display: block;
+}
+module[data-module="mini-profile"] .mini-profile .mp-avatar::after {
+  content: "";
+  position: absolute;
+  inset: -14%;
+  border-radius: 0;
+  background: var(--frame, none) center/contain no-repeat;
+  opacity: 1;
+  pointer-events: none;
+  z-index: 2;
+}
+module[data-module="mini-profile"] .mini-profile .mp-display {
+  font-weight: 800;
+  font-size: 16px;
+  color: #fff;
+}
+module[data-module="mini-profile"] .mini-profile .mp-name-line {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+module[data-module="mini-profile"] .mini-profile .mp-status-line {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+module[data-module="mini-profile"] .mini-profile .mp-status-text {
+  font-size: 12px;
+  color: #ddd;
+}
+module[data-module="mini-profile"] .mini-profile .status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #888;
+}
+module[data-module="mini-profile"] .mini-profile .status-dot[data-status="online"] { background: #3ba55d; }
+module[data-module="mini-profile"] .mini-profile .status-dot[data-status="away"] { background: #faa81a; }
+module[data-module="mini-profile"] .mini-profile .status-dot[data-status="dnd"] { background: #ed4245; }
+module[data-module="mini-profile"] .mini-profile .status-dot[data-status="offline"] { background: #5b5e66; }
+module[data-module="mini-profile"] .mini-profile .status-dot[data-status="live"] { background: #f50; }
+module[data-module="mini-profile"] .mini-profile .mp-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px 12px;
+  margin-top: -4px;
+}
+module[data-module="mini-profile"] .mini-profile .mp-btn,
+module[data-module="mini-profile"] .mini-profile .mp-icon {
+  background: #2a2c31;
+  color: #e6e6e6;
+  border: 1px solid #1b1d22;
+  padding: 8px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 13px;
+  transition: background .15s ease, color .15s ease, border-color .15s ease;
+}
+module[data-module="mini-profile"] .mini-profile .mp-btn.primary {
+  background: var(--accent, #5865f2);
+  border-color: transparent;
+  color: #fff;
+}
+module[data-module="mini-profile"] .mini-profile .mp-btn.primary:hover {
+  filter: brightness(1.05);
+}
+module[data-module="mini-profile"] .mini-profile .mp-icon {
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-size: 18px;
+  color: #bbb;
+}
+module[data-module="mini-profile"] .mini-profile .mp-icon:hover {
+  background: #34363c;
+  color: #fff;
+}

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -218,3 +218,14 @@ module[data-module="mini-profile"] .mini-profile .mp-activity-list .act-info spa
   color: #6b7280;
 }
 
+module[data-module="mini-profile"] .mini-profile .mp-activity-list .act-btn {
+  margin-left: auto;
+  background: var(--accent, #5865f2);
+  border: none;
+  color: #ffffff;
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -108,23 +108,22 @@ module[data-module="mini-profile"] .mini-profile .mp-actions {
   margin-top: 8px;
   display: flex;
   gap: 8px;
-  width: 100%;
+  justify-content: center;
 }
 
 module[data-module="mini-profile"] .mini-profile .mp-action {
-  flex: 1 1 0;
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 2px;
+  justify-content: center;
   background: var(--accent, #5865f2);
   border: none;
   color: #ffffff;
-  padding: 6px 4px;
-  font-size: 0.75rem;
+  padding: 0;
   border-radius: 6px;
   cursor: pointer;
-  text-align: center;
 }
 
 module[data-module="mini-profile"] .mini-profile .mp-action svg {

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -101,15 +101,32 @@ module[data-module="mini-profile"] .mini-profile .mp-tagline {
   color: #6b7280;
 }
 
-module[data-module="mini-profile"] .mini-profile .mp-edit {
+module[data-module="mini-profile"] .mini-profile .mp-actions {
   margin-top: 8px;
-  background: #e5e7eb;
-  border: 1px solid #d1d5db;
+  display: flex;
+  gap: 8px;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-action {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
   color: #1f2937;
-  padding: 4px 8px;
+  padding: 6px 8px;
   font-size: 0.875rem;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-action.icon-only {
+  padding: 6px;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-action svg {
+  width: 16px;
+  height: 16px;
 }
 
 module[data-module="mini-profile"] .mini-profile .mp-section {

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -28,7 +28,7 @@ module[data-module="mini-profile"] .mini-profile.hidden {
 module[data-module="mini-profile"] .mini-profile .mp-banner {
   height: 120px;
   background-color: #f3f4f6;
-  background-position: center top;
+  background-position: right top;
   background-size: cover;
   background-repeat: no-repeat;
   position: relative;

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -191,7 +191,30 @@ module[data-module="mini-profile"] .mini-profile .mp-activity-list {
 }
 
 module[data-module="mini-profile"] .mini-profile .mp-activity-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #f3f4f6;
+  border-radius: 4px;
+  padding: 6px 8px;
   font-size: 0.875rem;
   color: #1f2937;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-activity-list img {
+  width: 40px;
+  height: 24px;
+  object-fit: cover;
+  border-radius: 2px;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-activity-list .act-info {
+  display: flex;
+  flex-direction: column;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-activity-list .act-info span {
+  font-size: 0.75rem;
+  color: #6b7280;
 }
 

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -117,7 +117,7 @@ module[data-module="mini-profile"] .mini-profile .mp-action {
   background: var(--accent, #5865f2);
   border: none;
   color: #ffffff;
-  padding: 6px 8px;
+  padding: 4px 6px;
   font-size: 0.875rem;
   border-radius: 6px;
   cursor: pointer;

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -181,3 +181,17 @@ module[data-module="mini-profile"] .mini-profile .mp-note-text {
   color: #6b7280;
 }
 
+module[data-module="mini-profile"] .mini-profile .mp-activity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-activity-list li {
+  font-size: 0.875rem;
+  color: #1f2937;
+}
+

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -121,6 +121,7 @@ module[data-module="mini-profile"] .mini-profile .mp-action {
   font-size: 0.875rem;
   border-radius: 6px;
   cursor: pointer;
+  width: auto;
 }
 
 module[data-module="mini-profile"] .mini-profile .mp-action svg {
@@ -227,5 +228,6 @@ module[data-module="mini-profile"] .mini-profile .mp-activity-list .act-btn {
   font-size: 0.75rem;
   border-radius: 4px;
   cursor: pointer;
+  width: auto;
 }
 

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -111,9 +111,9 @@ module[data-module="mini-profile"] .mini-profile .mp-action {
   display: flex;
   align-items: center;
   gap: 4px;
-  background: #f3f4f6;
-  border: 1px solid #e5e7eb;
-  color: #1f2937;
+  background: var(--accent, #5865f2);
+  border: none;
+  color: #ffffff;
   padding: 6px 8px;
   font-size: 0.875rem;
   border-radius: 6px;
@@ -123,6 +123,18 @@ module[data-module="mini-profile"] .mini-profile .mp-action {
 module[data-module="mini-profile"] .mini-profile .mp-action svg {
   width: 16px;
   height: 16px;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-badges {
+  margin-top: 4px;
+  display: none;
+  gap: 4px;
+  justify-content: center;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-badges img {
+  width: 24px;
+  height: 24px;
 }
 
 module[data-module="mini-profile"] .mini-profile .mp-section {

--- a/module/mini-profile/mini-profile.css
+++ b/module/mini-profile/mini-profile.css
@@ -1,74 +1,75 @@
 module[data-module="mini-profile"] .mini-profile {
-  --mp-w: 320px;
-  --mp-radius: 12px;
+  --mp-w: 340px;
   position: fixed;
   z-index: 2000;
   width: var(--mp-w);
-  color: #1f2937;
   background: #ffffff;
+  color: #1f2937;
   border: 1px solid #e5e7eb;
-  border-radius: var(--mp-radius);
-  box-shadow: 0 20px 40px rgba(0,0,0,.1), 0 0 0 1px rgba(0,0,0,.05) inset;
+  border-radius: 8px;
+  box-shadow: 0 16px 40px rgba(0,0,0,.2);
   overflow: hidden;
   opacity: 0;
   transform: translateY(6px) scale(.98);
   transition: opacity .14s ease, transform .14s ease;
   pointer-events: none;
 }
+
 module[data-module="mini-profile"] .mini-profile.visible {
   opacity: 1;
   transform: translateY(0) scale(1);
   pointer-events: auto;
 }
+
 module[data-module="mini-profile"] .mini-profile.hidden {
   display: block;
 }
+
 module[data-module="mini-profile"] .mini-profile .mp-banner {
-  height: 92px;
-  background: var(--banner, linear-gradient(90deg, #f0f2f5, #e5e7eb));
-  background-position: center;
-  background-size: cover;
-  background-repeat: no-repeat;
+  height: 120px;
+  background: var(--banner, #f3f4f6) center/cover no-repeat;
   position: relative;
 }
+
 module[data-module="mini-profile"] .mini-profile .mp-banner::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(to bottom, rgba(255,255,255,.0) 20%, rgba(255,255,255,.35) 100%);
+  background: linear-gradient(to bottom, rgba(255,255,255,0) 20%, rgba(255,255,255,.35) 100%);
 }
+
 module[data-module="mini-profile"] .mini-profile .mp-accent {
-  position: relative;
-  height: 2px;
-  background: linear-gradient(90deg, var(--accent,#7c3aed), transparent 60%);
-  z-index: 2;
+  height: 4px;
+  background: var(--accent, #5865f2);
 }
+
 module[data-module="mini-profile"] .mini-profile .mp-body {
-  display: grid;
-  grid-template-columns: 72px 1fr;
-  gap: 12px;
-  padding: 12px;
-  position: relative;
-  z-index: 3;
+  padding: 0 16px 24px;
+  margin-top: -48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
+
 module[data-module="mini-profile"] .mini-profile .mp-avatar {
   position: relative;
-  width: 72px;
-  height: 72px;
+  width: 96px;
+  height: 96px;
   border-radius: 50%;
   overflow: visible;
   isolation: isolate;
-  margin-top: -36px;
-  z-index: 4;
 }
+
 module[data-module="mini-profile"] .mini-profile .mp-avatar::before {
   content: "";
   position: absolute;
-  inset: -4px;
+  inset: -6px;
   border-radius: 50%;
   background: #ffffff;
   z-index: 0;
 }
+
 module[data-module="mini-profile"] .mini-profile .mp-avatar img {
   position: relative;
   z-index: 1;
@@ -78,82 +79,77 @@ module[data-module="mini-profile"] .mini-profile .mp-avatar img {
   object-fit: cover;
   display: block;
 }
+
 module[data-module="mini-profile"] .mini-profile .mp-avatar::after {
   content: "";
   position: absolute;
-  inset: -14%;
-  border-radius: 0;
+  inset: -18%;
   background: var(--frame, none) center/contain no-repeat;
-  opacity: 1;
   pointer-events: none;
   z-index: 2;
 }
-module[data-module="mini-profile"] .mini-profile .mp-display {
-  font-weight: 800;
-  font-size: 16px;
-  color: #1f2937;
-}
-module[data-module="mini-profile"] .mini-profile .mp-name-line {
-  display: flex;
-  align-items: baseline;
-  gap: 6px;
-  flex-wrap: wrap;
-}
-module[data-module="mini-profile"] .mini-profile .mp-status-line {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  margin-top: 4px;
-}
-module[data-module="mini-profile"] .mini-profile .mp-status-text {
-  font-size: 12px;
-  color: #6b7280;
-}
-module[data-module="mini-profile"] .mini-profile .status-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: #9ca3af;
-}
-module[data-module="mini-profile"] .mini-profile .status-dot[data-status="online"] { background: #3ba55d; }
-module[data-module="mini-profile"] .mini-profile .status-dot[data-status="away"] { background: #faa81a; }
-module[data-module="mini-profile"] .mini-profile .status-dot[data-status="dnd"] { background: #ed4245; }
-module[data-module="mini-profile"] .mini-profile .status-dot[data-status="offline"] { background: #9ca3af; }
-module[data-module="mini-profile"] .mini-profile .status-dot[data-status="live"] { background: #f50; }
-module[data-module="mini-profile"] .mini-profile .mp-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 0 12px 12px;
-  margin-top: -4px;
-}
-module[data-module="mini-profile"] .mini-profile .mp-btn,
-module[data-module="mini-profile"] .mini-profile .mp-icon {
-  background: #f0f2f5;
-  color: #1f2937;
-  border: 1px solid #e5e7eb;
-  padding: 8px 10px;
-  border-radius: 8px;
-  cursor: pointer;
+
+module[data-module="mini-profile"] .mini-profile .mp-name {
+  margin-top: 12px;
+  font-size: 1.25rem;
   font-weight: 700;
-  font-size: 13px;
-  transition: background .15s ease, color .15s ease, border-color .15s ease;
 }
-module[data-module="mini-profile"] .mini-profile .mp-btn.primary {
-  background: var(--accent, #5865f2);
-  border-color: var(--accent, #5865f2);
-  color: #fff;
-}
-module[data-module="mini-profile"] .mini-profile .mp-btn.primary:hover {
-  filter: brightness(1.05);
-}
-module[data-module="mini-profile"] .mini-profile .mp-icon {
-  padding: 6px 8px;
-  border-radius: 8px;
-  font-size: 18px;
+
+module[data-module="mini-profile"] .mini-profile .mp-tagline {
+  margin-top: 4px;
+  font-size: 0.875rem;
   color: #6b7280;
 }
-module[data-module="mini-profile"] .mini-profile .mp-icon:hover {
+
+module[data-module="mini-profile"] .mini-profile .mp-edit {
+  margin-top: 8px;
   background: #e5e7eb;
+  border: 1px solid #d1d5db;
+  color: #1f2937;
+  padding: 4px 8px;
+  font-size: 0.875rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-section {
+  margin-top: 24px;
+  width: 100%;
+  text-align: left;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-section h3 {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin-bottom: 8px;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-about {
+  margin-top: 0;
+  font-size: 0.875rem;
+  color: #374151;
+  white-space: pre-wrap;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-member-date {
+  font-size: 0.875rem;
   color: #1f2937;
 }
+
+module[data-module="mini-profile"] .mini-profile .mp-conn-list {
+  display: flex;
+  gap: 8px;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-conn-list img {
+  width: 24px;
+  height: 24px;
+}
+
+module[data-module="mini-profile"] .mini-profile .mp-note-text {
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -72,16 +72,20 @@ export default async function init({ hub, root, utils }) {
           s.thumbnailId ? `<img src="${s.thumbnailId}" alt="" />` : ''
         }<div class="act-info"><strong>${s.title || 'Streaming'}</strong>${
           s.viewers ? `<span>${s.viewers} viewers</span>` : ''
-        }</div></li>`
+        }</div><button class="act-btn watch">Watch</button></li>`
       );
     } else if (status.online) {
       const entries = Object.entries(status.online).filter(([k, v]) => v);
       if (entries.length) {
         const [k, v] = entries[0];
+        const btn =
+          k === 'watching'
+            ? '<button class="act-btn join">Join</button>'
+            : '';
         cards.push(
           `<li class="activity-card online"><div class="act-info"><strong>${
             k.charAt(0).toUpperCase() + k.slice(1)
-          }</strong><span>${v}</span></div></li>`
+          }</strong><span>${v}</span></div>${btn}</li>`
         );
       } else {
         cards.push(

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -9,9 +9,10 @@ export default async function init({ hub, root, utils }) {
     support:
       '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M11.645 20.353a.75.75 0 0 0 .71 0 45.956 45.956 0 0 0 1.035-.62c1.588-.977 3.267-2.015 4.825-3.152C21.247 14.73 23 12.537 23 9.943 23 7.206 20.955 5 18.352 5c-1.542 0-3.01.876-3.708 2.18a.75.75 0 0 1-1.288 0C12.655 5.876 11.187 5 9.645 5 7.043 5 5 7.206 5 9.943c0 2.594 1.753 4.786 3.785 6.638 1.558 1.137 3.237 2.175 4.825 3.152.345.212.689.42 1.035.62Z" clip-rule="evenodd"/></svg>',
     shop:
-      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 6v.75H5.513c-.96 0-1.764.724-1.865 1.679l-1.263 12A1.875 1.875 0 0 0 4.25 22.5h15.5a1.875 1.875 0 0 0 1.865-2.071l-1.263-12a1.875 1.875 0 0 0-1.865-1.679H16.5V6a4.5 4.5 0 1 0-9 0ZM12 3a3 3 0 0 0-3 3v.75h6V6a3 3 0 0 0-3-3Zm-3 8.25a3 3 0 1 0 6 0v-.75a.75.75 0 0 1 1.5 0v.75a4.5 4.5 0 1 1-9 0v-.75a.75.75 0 0 1 1.5 0v.75Z" clip-rule="evenodd"/></svg>'
+      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 6v.75H5.513c-.964 0-1.764.724-1.865 1.679l-1.263 12A1.875 1.875 0 0 0 4.25 22.5h15.5a1.875 1.875 0 0 0 1.865-2.071l-1.263-12a1.875 1.875 0 0 0-1.865-1.679H16.5V6a4.5 4.5 0 1 0-9 0ZM12 3a3 3 0 0 0-3 3v.75h6V6a3 3 0 0 0-3-3Zm-3 8.25a3 3 0 1 0 6 0v-.75a.75.75 0 0 1 1.5 0v.75a4.5 4.5 0 1 1-9 0v-.75a.75.75 0 0 1 1.5 0v.75Z" clip-rule="evenodd"/></svg>',
+    stream:
+      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 3.5v17l14-8.5-14-8.5Z"/></svg>'
   };
-
   root.innerHTML = `
     <div class="mini-profile hidden" role="dialog" aria-modal="false" aria-hidden="true">
       <div class="mp-banner"></div>
@@ -106,6 +107,9 @@ export default async function init({ hub, root, utils }) {
       actions.innerHTML += `<button class="mp-action support">${icons.support}<span>Support</span></button>`;
     }
     actions.innerHTML += `<button class="mp-action shop">${icons.shop}<span>Shop</span></button>`;
+    if (user.streaming) {
+      actions.innerHTML += `<button class="mp-action stream">${icons.stream}<span>View Stream</span></button>`;
+    }
     if (user.badges && user.badges.length) {
       badgesEl.innerHTML = user.badges.slice(0,5).map((b) => `<img src="${b}" alt="badge" />`).join('');
       badgesEl.style.display = 'flex';
@@ -165,6 +169,7 @@ export default async function init({ hub, root, utils }) {
       const full = await getUserByToken(user.token).catch(() => ({}));
       user = { ...full, ...user };
     }
+    user.streaming = user.streaming || !!(user.status && user.status.streaming);
     fill(user);
     position(x, y);
     card.classList.add('visible');
@@ -185,7 +190,8 @@ export default async function init({ hub, root, utils }) {
     if (e.key === 'Escape') hide();
   });
 
-  utils.delegate(document, 'contextmenu', '[data-profile-name]', (e, el) => {
+  utils.delegate(document, 'click', '[data-profile-name]', (e, el) => {
+    if (e.button !== 0) return;
     e.preventDefault();
     const user = {
       name: el.dataset.profileName,
@@ -205,30 +211,6 @@ export default async function init({ hub, root, utils }) {
       streaming: el.dataset.profileStreaming === 'true'
     };
     show(user, e.pageX, e.pageY);
-  });
-
-  utils.delegate(document, 'click', '[data-profile-name]', (e, el) => {
-    if (e.button !== 0) return;
-    e.preventDefault();
-    hide();
-    const user = {
-      name: el.dataset.profileName,
-      token: el.dataset.profileToken,
-      avatar: el.dataset.profileAvatar,
-      banner: el.dataset.profileBanner,
-      accent: el.dataset.profileAccent,
-      frame: el.dataset.profileFrame,
-      bio: el.dataset.profileBio,
-      memberSince: el.dataset.profileSince,
-      connections: el.dataset.profileConnections
-        ? el.dataset.profileConnections.split(',')
-        : [],
-      badges: el.dataset.profileBadges
-        ? el.dataset.profileBadges.split(',')
-        : [],
-      streaming: el.dataset.profileStreaming === 'true'
-    };
-    hub.api['profile-overlay'].show(user);
   });
 
   return { show, hide };

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -190,8 +190,7 @@ export default async function init({ hub, root, utils }) {
     if (e.key === 'Escape') hide();
   });
 
-  utils.delegate(document, 'click', '[data-profile-name]', (e, el) => {
-    if (e.button !== 0) return;
+  utils.delegate(document, 'contextmenu', '[data-profile-name]', (e, el) => {
     e.preventDefault();
     const user = {
       name: el.dataset.profileName,

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -61,6 +61,30 @@ export default async function init({ hub, root, utils }) {
   const activitySection = card.querySelector('.mp-activity');
   const activityList = card.querySelector('.mp-activity-list');
 
+  let tooltip;
+  function showTooltip(el) {
+    const title = el.getAttribute('aria-label');
+    if (!title) return;
+    tooltip = document.createElement('div');
+    tooltip.className = 'navigation-small-tooltip';
+    tooltip.textContent = title;
+    tooltip.style.zIndex = '2100';
+    document.body.appendChild(tooltip);
+    const rect = el.getBoundingClientRect();
+    tooltip.style.top = `${rect.top + rect.height / 2}px`;
+    tooltip.style.left = `${rect.right}px`;
+    requestAnimationFrame(() => tooltip.classList.add('visible'));
+  }
+  function hideTooltip() {
+    if (tooltip) {
+      tooltip.remove();
+      tooltip = null;
+    }
+  }
+
+  utils.delegate(actions, 'mouseover', '.mp-action', (e, el) => showTooltip(el));
+  utils.delegate(actions, 'mouseout', '.mp-action', hideTooltip);
+
   function activityCards(user = {}) {
     const cards = [];
     const status = user.status || {};
@@ -206,6 +230,7 @@ export default async function init({ hub, root, utils }) {
   }
 
   function hide() {
+    hideTooltip();
     card.classList.remove('visible');
     card.classList.add('hidden');
   }

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -1,4 +1,13 @@
 export default async function init({ hub, root, utils }) {
+  const loggedIn = await fetch('/data/logged-in.json').then(r => r.json()).catch(() => null);
+
+  const icons = {
+    edit: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M21.731 2.269a2.625 2.625 0 0 0-3.712 0l-1.157 1.157 3.712 3.712 1.157-1.157a2.625 2.625 0 0 0 0-3.712ZM19.513 8.199l-3.712-3.712-12.15 12.15a5.25 5.25 0 0 0-1.32 2.214l-.8 2.685a.75.75 0 0 0 .933.933l2.685-.8a5.25 5.25 0 0 0 2.214-1.32l12.15-12.15Z"/></svg>',
+    shop: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 6v.75H5.513c-.96 0-1.764.724-1.865 1.679l-1.263 12A1.875 1.875 0 0 0 4.25 22.5h15.5a1.875 1.875 0 0 0 1.865-2.071l-1.263-12a1.875 1.875 0 0 0-1.865-1.679H16.5V6a4.5 4.5 0 1 0-9 0ZM12 3a3 3 0 0 0-3 3v.75h6V6a3 3 0 0 0-3-3Zm-3 8.25a3 3 0 1 0 6 0v-.75a.75.75 0 0 1 1.5 0v.75a4.5 4.5 0 1 1-9 0v-.75a.75.75 0 0 1 1.5 0v.75Z" clip-rule="evenodd"/></svg>',
+    chat: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M4.848 2.771A49.144 49.144 0 0 1 12 2.25c2.43 0 4.817.178 7.152.52 1.978.292 3.348 2.024 3.348 3.97v6.02c0 1.946-1.37 3.678-3.348 3.97-1.94.284-3.916.455-5.922.505a.39.39 0 0 0-.266.112L8.78 21.53A.75.75 0 0 1 7.5 21v-3.955a48.842 48.842 0 0 1-2.652-.316c-1.978-.29-3.348-2.024-3.348-3.97V6.741c0-1.946 1.37-3.68 3.348-3.97Z" clip-rule="evenodd"/></svg>',
+    stream: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.5 4.5a3 3 0 0 0-3 3v9a3 3 0 0 0 3 3h8.25a3 3 0 0 0 3-3v-9a3 3 0 0 0-3-3H4.5ZM19.94 18.75l-2.69-2.69V7.94l2.69-2.69c.944-.945 2.56-.276 2.56 1.06v11.38c0 1.336-1.616 2.005-2.56 1.06Z"/></svg>'
+  };
+
   root.innerHTML = `
     <div class="mini-profile hidden" role="dialog" aria-modal="false" aria-hidden="true">
       <div class="mp-banner"></div>
@@ -7,7 +16,7 @@ export default async function init({ hub, root, utils }) {
         <div class="mp-avatar"><img alt="" /></div>
         <h2 class="mp-name"></h2>
         <p class="mp-tagline"></p>
-        <button class="mp-edit">Edit Profile</button>
+        <div class="mp-actions"></div>
         <div class="mp-section mp-about-section">
           <h3>About Me</h3>
           <p class="mp-about"></p>
@@ -33,6 +42,7 @@ export default async function init({ hub, root, utils }) {
   const avatarImg = card.querySelector('.mp-avatar img');
   const nameEl = card.querySelector('.mp-name');
   const tagEl = card.querySelector('.mp-tagline');
+  const actions = card.querySelector('.mp-actions');
   const aboutSection = card.querySelector('.mp-about-section');
   const aboutEl = card.querySelector('.mp-about');
   const memberDateEl = card.querySelector('.mp-member-date');
@@ -51,6 +61,17 @@ export default async function init({ hub, root, utils }) {
     } else {
       tagEl.textContent = '';
       tagEl.style.display = 'none';
+    }
+
+    actions.innerHTML = '';
+    const isSelf = user.slug === loggedIn;
+    if (isSelf) {
+      actions.innerHTML += `<button class="mp-action edit">${icons.edit}<span>Edit Profile</span></button>`;
+    }
+    actions.innerHTML += `<button class="mp-action icon-only shop" title="Shop">${icons.shop}</button>`;
+    actions.innerHTML += `<button class="mp-action icon-only chat" title="Chat">${icons.chat}</button>`;
+    if (user.streaming) {
+      actions.innerHTML += `<button class="mp-action icon-only stream" title="Stream">${icons.stream}</button>`;
     }
     if (user.about) {
       aboutEl.textContent = user.about;
@@ -125,6 +146,7 @@ export default async function init({ hub, root, utils }) {
       connections: el.dataset.profileConnections
         ? el.dataset.profileConnections.split(',')
         : [],
+      streaming: el.dataset.profileStreaming === 'true'
     };
     show(user, e.pageX, e.pageY);
   });
@@ -145,6 +167,7 @@ export default async function init({ hub, root, utils }) {
       connections: el.dataset.profileConnections
         ? el.dataset.profileConnections.split(',')
         : [],
+      streaming: el.dataset.profileStreaming === 'true'
     };
     hub.api['profile-overlay'].show(user);
   });

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -37,23 +37,22 @@ export default async function init({ hub, root, utils }) {
     display.textContent = user.name || 'Unknown';
   }
 
-  function position(anchor) {
-    const rect = anchor.getBoundingClientRect();
+  function position(x, y) {
     const mpW = card.offsetWidth;
     const mpH = card.offsetHeight;
-    let left = rect.right + 8;
-    if (left + mpW > window.innerWidth - 8) left = rect.left - mpW - 8;
+    let left = x + 8;
+    if (left + mpW > window.innerWidth - 8) left = x - mpW - 8;
     if (left < 8) left = 8;
-    let top = rect.top;
+    let top = y;
     if (top + mpH > window.innerHeight - 8) top = window.innerHeight - mpH - 8;
     if (top < 8) top = 8;
-    card.style.left = `${left + window.scrollX}px`;
-    card.style.top = `${top + window.scrollY}px`;
+    card.style.left = `${left}px`;
+    card.style.top = `${top}px`;
   }
 
-  function show(user, anchor) {
+  function show(user, x, y) {
     fill(user);
-    position(anchor);
+    position(x, y);
     card.classList.add('visible');
     card.classList.remove('hidden');
   }
@@ -72,7 +71,8 @@ export default async function init({ hub, root, utils }) {
     if (e.key === 'Escape') hide();
   });
 
-  utils.delegate(document, 'click', '[data-profile-name]', (e, el) => {
+  utils.delegate(document, 'contextmenu', '[data-profile-name]', (e, el) => {
+    e.preventDefault();
     const user = {
       name: el.dataset.profileName,
       avatar: el.dataset.profileAvatar,
@@ -80,7 +80,21 @@ export default async function init({ hub, root, utils }) {
       accent: el.dataset.profileAccent,
       frame: el.dataset.profileFrame,
     };
-    show(user, el);
+    show(user, e.pageX, e.pageY);
+  });
+
+  utils.delegate(document, 'click', '[data-profile-name]', (e, el) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    hide();
+    const user = {
+      name: el.dataset.profileName,
+      avatar: el.dataset.profileAvatar,
+      banner: el.dataset.profileBanner,
+      accent: el.dataset.profileAccent,
+      frame: el.dataset.profileFrame,
+    };
+    window.LoadMainModule('profile', { user });
   });
 
   return { show, hide };

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -2,10 +2,12 @@ export default async function init({ hub, root, utils }) {
   const loggedIn = await fetch('/data/logged-in.json').then(r => r.json()).catch(() => null);
 
   const icons = {
-    edit: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M21.731 2.269a2.625 2.625 0 0 0-3.712 0l-1.157 1.157 3.712 3.712 1.157-1.157a2.625 2.625 0 0 0 0-3.712ZM19.513 8.199l-3.712-3.712-12.15 12.15a5.25 5.25 0 0 0-1.32 2.214l-.8 2.685a.75.75 0 0 0 .933.933l2.685-.8a5.25 5.25 0 0 0 2.214-1.32l12.15-12.15Z"/></svg>',
-    shop: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 6v.75H5.513c-.96 0-1.764.724-1.865 1.679l-1.263 12A1.875 1.875 0 0 0 4.25 22.5h15.5a1.875 1.875 0 0 0 1.865-2.071l-1.263-12a1.875 1.875 0 0 0-1.865-1.679H16.5V6a4.5 4.5 0 1 0-9 0ZM12 3a3 3 0 0 0-3 3v.75h6V6a3 3 0 0 0-3-3Zm-3 8.25a3 3 0 1 0 6 0v-.75a.75.75 0 0 1 1.5 0v.75a4.5 4.5 0 1 1-9 0v-.75a.75.75 0 0 1 1.5 0v.75Z" clip-rule="evenodd"/></svg>',
-    chat: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M4.848 2.771A49.144 49.144 0 0 1 12 2.25c2.43 0 4.817.178 7.152.52 1.978.292 3.348 2.024 3.348 3.97v6.02c0 1.946-1.37 3.678-3.348 3.97-1.94.284-3.916.455-5.922.505a.39.39 0 0 0-.266.112L8.78 21.53A.75.75 0 0 1 7.5 21v-3.955a48.842 48.842 0 0 1-2.652-.316c-1.978-.29-3.348-2.024-3.348-3.97V6.741c0-1.946 1.37-3.68 3.348-3.97Z" clip-rule="evenodd"/></svg>',
-    stream: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.5 4.5a3 3 0 0 0-3 3v9a3 3 0 0 0 3 3h8.25a3 3 0 0 0 3-3v-9a3 3 0 0 0-3-3H4.5ZM19.94 18.75l-2.69-2.69V7.94l2.69-2.69c.944-.945 2.56-.276 2.56 1.06v11.38c0 1.336-1.616 2.005-2.56 1.06Z"/></svg>'
+    follow:
+      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 7a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"/><path fill-rule="evenodd" d="M12 14a7 7 0 0 0-7 7 .75.75 0 0 0 1.5 0 5.5 5.5 0 0 1 11 0 .75.75 0 0 0 1.5 0 7 7 0 0 0-7-7Z" clip-rule="evenodd"/><path d="M19 7a1 1 0 1 0 0-2h-1V4a1 1 0 1 0-2 0v1h-1a1 1 0 1 0 0 2h1v1a1 1 0 1 0 2 0V7h1Z"/></svg>',
+    support:
+      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M11.645 20.353a.75.75 0 0 0 .71 0 45.956 45.956 0 0 0 1.035-.62c1.588-.977 3.267-2.015 4.825-3.152C21.247 14.73 23 12.537 23 9.943 23 7.206 20.955 5 18.352 5c-1.542 0-3.01.876-3.708 2.18a.75.75 0 0 1-1.288 0C12.655 5.876 11.187 5 9.645 5 7.043 5 5 7.206 5 9.943c0 2.594 1.753 4.786 3.785 6.638 1.558 1.137 3.237 2.175 4.825 3.152.345.212.689.42 1.035.62Z" clip-rule="evenodd"/></svg>',
+    shop:
+      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 6v.75H5.513c-.96 0-1.764.724-1.865 1.679l-1.263 12A1.875 1.875 0 0 0 4.25 22.5h15.5a1.875 1.875 0 0 0 1.865-2.071l-1.263-12a1.875 1.875 0 0 0-1.865-1.679H16.5V6a4.5 4.5 0 1 0-9 0ZM12 3a3 3 0 0 0-3 3v.75h6V6a3 3 0 0 0-3-3Zm-3 8.25a3 3 0 1 0 6 0v-.75a.75.75 0 0 1 1.5 0v.75a4.5 4.5 0 1 1-9 0v-.75a.75.75 0 0 1 1.5 0v.75Z" clip-rule="evenodd"/></svg>'
   };
 
   root.innerHTML = `
@@ -65,14 +67,11 @@ export default async function init({ hub, root, utils }) {
 
     actions.innerHTML = '';
     const isSelf = user.slug === loggedIn;
-    if (isSelf) {
-      actions.innerHTML += `<button class="mp-action edit">${icons.edit}<span>Edit Profile</span></button>`;
+    if (!isSelf) {
+      actions.innerHTML += `<button class="mp-action follow">${icons.follow}<span>Follow</span></button>`;
+      actions.innerHTML += `<button class="mp-action support">${icons.support}<span>Support</span></button>`;
     }
-    actions.innerHTML += `<button class="mp-action icon-only shop" title="Shop">${icons.shop}</button>`;
-    actions.innerHTML += `<button class="mp-action icon-only chat" title="Chat">${icons.chat}</button>`;
-    if (user.streaming) {
-      actions.innerHTML += `<button class="mp-action icon-only stream" title="Stream">${icons.stream}</button>`;
-    }
+    actions.innerHTML += `<button class="mp-action shop">${icons.shop}<span>Shop</span></button>`;
     if (user.about) {
       aboutEl.textContent = user.about;
       aboutSection.style.display = 'block';

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -5,36 +5,76 @@ export default async function init({ hub, root, utils }) {
       <div class="mp-accent"></div>
       <div class="mp-body">
         <div class="mp-avatar"><img alt="" /></div>
-        <div class="mp-meta">
-          <div class="mp-name-line">
-            <span class="mp-display"></span>
-          </div>
-          <div class="mp-status-line">
-            <span class="status-dot" data-status="offline"></span>
-            <span class="mp-status-text">Offline</span>
-          </div>
+        <h2 class="mp-name"></h2>
+        <p class="mp-tagline"></p>
+        <button class="mp-edit">Edit Profile</button>
+        <div class="mp-section mp-about-section">
+          <h3>About Me</h3>
+          <p class="mp-about"></p>
+        </div>
+        <div class="mp-section mp-member">
+          <h3>Member Since</h3>
+          <p class="mp-member-date"></p>
+        </div>
+        <div class="mp-section mp-connections">
+          <h3>Connections</h3>
+          <div class="mp-conn-list"></div>
+        </div>
+        <div class="mp-section mp-note">
+          <h3>Note</h3>
+          <p class="mp-note-text">Click to add a note</p>
         </div>
       </div>
-      <div class="mp-actions"></div>
     </div>
   `;
 
   const card = root.querySelector('.mini-profile');
   const banner = card.querySelector('.mp-banner');
   const avatarImg = card.querySelector('.mp-avatar img');
-  const display = card.querySelector('.mp-display');
+  const nameEl = card.querySelector('.mp-name');
+  const tagEl = card.querySelector('.mp-tagline');
+  const aboutSection = card.querySelector('.mp-about-section');
+  const aboutEl = card.querySelector('.mp-about');
+  const memberDateEl = card.querySelector('.mp-member-date');
+  const connList = card.querySelector('.mp-conn-list');
 
-  function fill(user) {
+  function fill(user = {}) {
     card.style.setProperty('--accent', user.accent || '#5865f2');
     card.style.setProperty('--frame', user.frame ? `url('${user.frame}')` : 'none');
-    if (user.banner) {
-      banner.style.backgroundImage = `url("${user.banner}")`;
-    } else {
-      banner.style.backgroundImage = 'none';
-    }
+    banner.style.backgroundImage = user.banner ? `url("${user.banner}")` : 'none';
     avatarImg.src = user.avatar || '';
     avatarImg.alt = user.name || '';
-    display.textContent = user.name || 'Unknown';
+    nameEl.textContent = user.name || '';
+    if (user.slug) {
+      tagEl.textContent = `@${user.slug}`;
+      tagEl.style.display = 'block';
+    } else {
+      tagEl.textContent = '';
+      tagEl.style.display = 'none';
+    }
+    if (user.about) {
+      aboutEl.textContent = user.about;
+      aboutSection.style.display = 'block';
+    } else {
+      aboutEl.textContent = '';
+      aboutSection.style.display = 'none';
+    }
+    if (user.memberSince) {
+      memberDateEl.textContent = user.memberSince;
+      memberDateEl.closest('.mp-member').style.display = 'block';
+    } else {
+      memberDateEl.textContent = '';
+      memberDateEl.closest('.mp-member').style.display = 'none';
+    }
+    if (user.connections && user.connections.length) {
+      connList.innerHTML = user.connections
+        .map((c) => `<img src="${c}" alt="connection" />`)
+        .join('');
+      connList.closest('.mp-connections').style.display = 'block';
+    } else {
+      connList.innerHTML = '';
+      connList.closest('.mp-connections').style.display = 'none';
+    }
   }
 
   function position(x, y) {
@@ -75,10 +115,16 @@ export default async function init({ hub, root, utils }) {
     e.preventDefault();
     const user = {
       name: el.dataset.profileName,
+      slug: el.dataset.profileSlug,
       avatar: el.dataset.profileAvatar,
       banner: el.dataset.profileBanner,
       accent: el.dataset.profileAccent,
       frame: el.dataset.profileFrame,
+      about: el.dataset.profileAbout,
+      memberSince: el.dataset.profileSince,
+      connections: el.dataset.profileConnections
+        ? el.dataset.profileConnections.split(',')
+        : [],
     };
     show(user, e.pageX, e.pageY);
   });
@@ -89,6 +135,7 @@ export default async function init({ hub, root, utils }) {
     hide();
     const user = {
       name: el.dataset.profileName,
+      slug: el.dataset.profileSlug,
       avatar: el.dataset.profileAvatar,
       banner: el.dataset.profileBanner,
       accent: el.dataset.profileAccent,

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -94,7 +94,7 @@ export default async function init({ hub, root, utils }) {
       accent: el.dataset.profileAccent,
       frame: el.dataset.profileFrame,
     };
-    window.LoadMainModule('profile', { user });
+    hub.api['profile-overlay'].show(user);
   });
 
   return { show, hide };

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -39,10 +39,6 @@ export default async function init({ hub, root, utils }) {
           <h3>Activity</h3>
           <ul class="mp-activity-list"></ul>
         </div>
-        <div class="mp-section mp-note">
-          <h3>Note</h3>
-          <p class="mp-note-text">Click to add a note</p>
-        </div>
       </div>
     </div>
   `;

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -93,6 +93,11 @@ export default async function init({ hub, root, utils }) {
       banner: el.dataset.profileBanner,
       accent: el.dataset.profileAccent,
       frame: el.dataset.profileFrame,
+      about: el.dataset.profileAbout,
+      memberSince: el.dataset.profileSince,
+      connections: el.dataset.profileConnections
+        ? el.dataset.profileConnections.split(',')
+        : [],
     };
     hub.api['profile-overlay'].show(user);
   });

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -18,6 +18,7 @@ export default async function init({ hub, root, utils }) {
         <div class="mp-avatar"><img alt="" /></div>
         <h2 class="mp-name"></h2>
         <p class="mp-tagline"></p>
+        <div class="mp-badges"></div>
         <div class="mp-actions"></div>
         <div class="mp-section mp-about-section">
           <h3>About Me</h3>
@@ -45,6 +46,7 @@ export default async function init({ hub, root, utils }) {
   const nameEl = card.querySelector('.mp-name');
   const tagEl = card.querySelector('.mp-tagline');
   const actions = card.querySelector('.mp-actions');
+  const badgesEl = card.querySelector('.mp-badges');
   const aboutSection = card.querySelector('.mp-about-section');
   const aboutEl = card.querySelector('.mp-about');
   const memberDateEl = card.querySelector('.mp-member-date');
@@ -72,6 +74,13 @@ export default async function init({ hub, root, utils }) {
       actions.innerHTML += `<button class="mp-action support">${icons.support}<span>Support</span></button>`;
     }
     actions.innerHTML += `<button class="mp-action shop">${icons.shop}<span>Shop</span></button>`;
+    if (user.badges && user.badges.length) {
+      badgesEl.innerHTML = user.badges.slice(0,5).map((b) => `<img src="${b}" alt="badge" />`).join('');
+      badgesEl.style.display = 'flex';
+    } else {
+      badgesEl.innerHTML = '';
+      badgesEl.style.display = 'none';
+    }
     if (user.about) {
       aboutEl.textContent = user.about;
       aboutSection.style.display = 'block';
@@ -145,6 +154,9 @@ export default async function init({ hub, root, utils }) {
       connections: el.dataset.profileConnections
         ? el.dataset.profileConnections.split(',')
         : [],
+      badges: el.dataset.profileBadges
+        ? el.dataset.profileBadges.split(',')
+        : [],
       streaming: el.dataset.profileStreaming === 'true'
     };
     show(user, e.pageX, e.pageY);
@@ -165,6 +177,9 @@ export default async function init({ hub, root, utils }) {
       memberSince: el.dataset.profileSince,
       connections: el.dataset.profileConnections
         ? el.dataset.profileConnections.split(',')
+        : [],
+      badges: el.dataset.profileBadges
+        ? el.dataset.profileBadges.split(',')
         : [],
       streaming: el.dataset.profileStreaming === 'true'
     };

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -132,12 +132,12 @@ export default async function init({ hub, root, utils }) {
     actions.innerHTML = '';
     const isSelf = user.token === loggedIn;
     if (!isSelf) {
-      actions.innerHTML += `<button class="mp-action follow">${icons.follow}<span>Follow</span></button>`;
-      actions.innerHTML += `<button class="mp-action support">${icons.support}<span>Support</span></button>`;
+      actions.innerHTML += `<button class="mp-action follow" aria-label="Follow">${icons.follow}</button>`;
+      actions.innerHTML += `<button class="mp-action support" aria-label="Support">${icons.support}</button>`;
     }
-    actions.innerHTML += `<button class="mp-action shop">${icons.shop}<span>Shop</span></button>`;
+    actions.innerHTML += `<button class="mp-action shop" aria-label="Shop">${icons.shop}</button>`;
     if (user.streaming) {
-      actions.innerHTML += `<button class="mp-action stream">${icons.stream}<span>View Stream</span></button>`;
+      actions.innerHTML += `<button class="mp-action stream" aria-label="View Stream">${icons.stream}</button>`;
     }
     if (user.badges && user.badges.length) {
       badgesEl.innerHTML = user.badges.slice(0,5).map((b) => `<img src="${b}" alt="badge" />`).join('');

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -59,8 +59,8 @@ export default async function init({ hub, root, utils }) {
     avatarImg.src = user.avatar || '';
     avatarImg.alt = user.name || '';
     nameEl.textContent = user.name || '';
-    if (user.slug) {
-      tagEl.textContent = `@${user.slug}`;
+    if (user.token) {
+      tagEl.textContent = `@${user.token}`;
       tagEl.style.display = 'block';
     } else {
       tagEl.textContent = '';
@@ -68,7 +68,7 @@ export default async function init({ hub, root, utils }) {
     }
 
     actions.innerHTML = '';
-    const isSelf = user.slug === loggedIn;
+    const isSelf = user.token === loggedIn;
     if (!isSelf) {
       actions.innerHTML += `<button class="mp-action follow">${icons.follow}<span>Follow</span></button>`;
       actions.innerHTML += `<button class="mp-action support">${icons.support}<span>Support</span></button>`;
@@ -81,8 +81,8 @@ export default async function init({ hub, root, utils }) {
       badgesEl.innerHTML = '';
       badgesEl.style.display = 'none';
     }
-    if (user.about) {
-      aboutEl.textContent = user.about;
+    if (user.bio) {
+      aboutEl.textContent = user.bio;
       aboutSection.style.display = 'block';
     } else {
       aboutEl.textContent = '';
@@ -144,12 +144,12 @@ export default async function init({ hub, root, utils }) {
     e.preventDefault();
     const user = {
       name: el.dataset.profileName,
-      slug: el.dataset.profileSlug,
+      token: el.dataset.profileToken,
       avatar: el.dataset.profileAvatar,
       banner: el.dataset.profileBanner,
       accent: el.dataset.profileAccent,
       frame: el.dataset.profileFrame,
-      about: el.dataset.profileAbout,
+      bio: el.dataset.profileBio,
       memberSince: el.dataset.profileSince,
       connections: el.dataset.profileConnections
         ? el.dataset.profileConnections.split(',')
@@ -168,12 +168,12 @@ export default async function init({ hub, root, utils }) {
     hide();
     const user = {
       name: el.dataset.profileName,
-      slug: el.dataset.profileSlug,
+      token: el.dataset.profileToken,
       avatar: el.dataset.profileAvatar,
       banner: el.dataset.profileBanner,
       accent: el.dataset.profileAccent,
       frame: el.dataset.profileFrame,
-      about: el.dataset.profileAbout,
+      bio: el.dataset.profileBio,
       memberSince: el.dataset.profileSince,
       connections: el.dataset.profileConnections
         ? el.dataset.profileConnections.split(',')

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -1,0 +1,87 @@
+export default async function init({ hub, root, utils }) {
+  root.innerHTML = `
+    <div class="mini-profile hidden" role="dialog" aria-modal="false" aria-hidden="true">
+      <div class="mp-banner"></div>
+      <div class="mp-accent"></div>
+      <div class="mp-body">
+        <div class="mp-avatar"><img alt="" /></div>
+        <div class="mp-meta">
+          <div class="mp-name-line">
+            <span class="mp-display"></span>
+          </div>
+          <div class="mp-status-line">
+            <span class="status-dot" data-status="offline"></span>
+            <span class="mp-status-text">Offline</span>
+          </div>
+        </div>
+      </div>
+      <div class="mp-actions"></div>
+    </div>
+  `;
+
+  const card = root.querySelector('.mini-profile');
+  const banner = card.querySelector('.mp-banner');
+  const avatarImg = card.querySelector('.mp-avatar img');
+  const display = card.querySelector('.mp-display');
+
+  function fill(user) {
+    card.style.setProperty('--accent', user.accent || '#5865f2');
+    card.style.setProperty('--frame', user.frame ? `url('${user.frame}')` : 'none');
+    if (user.banner) {
+      banner.style.backgroundImage = `url("${user.banner}")`;
+    } else {
+      banner.style.backgroundImage = 'none';
+    }
+    avatarImg.src = user.avatar || '';
+    avatarImg.alt = user.name || '';
+    display.textContent = user.name || 'Unknown';
+  }
+
+  function position(anchor) {
+    const rect = anchor.getBoundingClientRect();
+    const mpW = card.offsetWidth;
+    const mpH = card.offsetHeight;
+    let left = rect.right + 8;
+    if (left + mpW > window.innerWidth - 8) left = rect.left - mpW - 8;
+    if (left < 8) left = 8;
+    let top = rect.top;
+    if (top + mpH > window.innerHeight - 8) top = window.innerHeight - mpH - 8;
+    if (top < 8) top = 8;
+    card.style.left = `${left + window.scrollX}px`;
+    card.style.top = `${top + window.scrollY}px`;
+  }
+
+  function show(user, anchor) {
+    fill(user);
+    position(anchor);
+    card.classList.add('visible');
+    card.classList.remove('hidden');
+  }
+
+  function hide() {
+    card.classList.remove('visible');
+    card.classList.add('hidden');
+  }
+
+  utils.listen(document, 'click', (e) => {
+    if (!card.classList.contains('visible')) return;
+    if (!card.contains(e.target)) hide();
+  });
+
+  utils.listen(document, 'keydown', (e) => {
+    if (e.key === 'Escape') hide();
+  });
+
+  utils.delegate(document, 'click', '[data-profile-name]', (e, el) => {
+    const user = {
+      name: el.dataset.profileName,
+      avatar: el.dataset.profileAvatar,
+      banner: el.dataset.profileBanner,
+      accent: el.dataset.profileAccent,
+      frame: el.dataset.profileFrame,
+    };
+    show(user, el);
+  });
+
+  return { show, hide };
+}

--- a/module/mini-profile/mini-profile.js
+++ b/module/mini-profile/mini-profile.js
@@ -36,7 +36,7 @@ export default async function init({ hub, root, utils }) {
           <div class="mp-conn-list"></div>
         </div>
         <div class="mp-section mp-activity">
-          <h3>Customizing My Profile</h3>
+          <h3>Activity</h3>
           <ul class="mp-activity-list"></ul>
         </div>
         <div class="mp-section mp-note">
@@ -61,28 +61,53 @@ export default async function init({ hub, root, utils }) {
   const activitySection = card.querySelector('.mp-activity');
   const activityList = card.querySelector('.mp-activity-list');
 
-  function activityLines(user = {}) {
-    const lines = [];
+  function activityCards(user = {}) {
+    const cards = [];
     const status = user.status || {};
+
     if (status.streaming) {
-      lines.push(`Streaming ${status.streaming.title || ''}`);
+      const s = status.streaming;
+      cards.push(
+        `<li class="activity-card streaming">${
+          s.thumbnailId ? `<img src="${s.thumbnailId}" alt="" />` : ''
+        }<div class="act-info"><strong>${s.title || 'Streaming'}</strong>${
+          s.viewers ? `<span>${s.viewers} viewers</span>` : ''
+        }</div></li>`
+      );
     } else if (status.online) {
       const entries = Object.entries(status.online).filter(([k, v]) => v);
       if (entries.length) {
         const [k, v] = entries[0];
-        lines.push(`${k.charAt(0).toUpperCase() + k.slice(1)} ${v}`);
+        cards.push(
+          `<li class="activity-card online"><div class="act-info"><strong>${
+            k.charAt(0).toUpperCase() + k.slice(1)
+          }</strong><span>${v}</span></div></li>`
+        );
       } else {
-        lines.push('Online');
+        cards.push(
+          '<li class="activity-card online"><div class="act-info"><strong>Online</strong></div></li>'
+        );
       }
     } else if (status.away !== null) {
-      lines.push('Away');
+      cards.push(
+        '<li class="activity-card away"><div class="act-info"><strong>Away</strong></div></li>'
+      );
     } else if (status.dnd !== null) {
-      lines.push('Do Not Disturb');
+      cards.push(
+        '<li class="activity-card dnd"><div class="act-info"><strong>Do Not Disturb</strong></div></li>'
+      );
     }
+
     if (user.hosting) {
-      lines.push(`Hosting ${user.hosting.title || ''}`);
+      const h = user.hosting;
+      cards.push(
+        `<li class="activity-card hosting">${
+          h.thumbnailId ? `<img src="${h.thumbnailId}" alt="" />` : ''
+        }<div class="act-info"><strong>Hosting ${h.title || ''}</strong></div></li>`
+      );
     }
-    return lines;
+
+    return cards;
   }
 
   function fill(user = {}) {
@@ -141,9 +166,9 @@ export default async function init({ hub, root, utils }) {
       connList.closest('.mp-connections').style.display = 'none';
     }
 
-    const acts = activityLines(user);
+    const acts = activityCards(user);
     if (acts.length) {
-      activityList.innerHTML = acts.map((a) => `<li>${a}</li>`).join('');
+      activityList.innerHTML = acts.join('');
       activitySection.style.display = 'block';
     } else {
       activityList.innerHTML = '';

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -1,4 +1,4 @@
-import { getUserBySlug } from '../users.js';
+import { getUserByToken } from '../users.js';
 
 export default async function init({ hub, root, utils }) {
   const res = await fetch('modules-enabled.json');
@@ -11,12 +11,12 @@ export default async function init({ hub, root, utils }) {
       icon: `#svg-${m.icon}`
     }));
 
-  const loggedSlug = await fetch('/data/logged-in.json').then(r => r.json());
-  const currentUser = await getUserBySlug(loggedSlug);
+  const loggedToken = await fetch('/data/logged-in.json').then(r => r.json());
+  const currentUser = await getUserByToken(loggedToken);
 
   root.innerHTML = `
     <nav class="navigation-small" data-role="small">
-      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-badges="${(currentUser.badges || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">
+      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-token="${currentUser.token}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-bio="${currentUser.bio || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-badges="${(currentUser.badges || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">
         <img
           class="avatar-image"
           src="${currentUser.avatar}"
@@ -44,14 +44,14 @@ export default async function init({ hub, root, utils }) {
           alt=""
           aria-hidden="true"
         />
-        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-badges="${(currentUser.badges || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">
+        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-token="${currentUser.token}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-bio="${currentUser.bio || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-badges="${(currentUser.badges || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">
           <img
             class="avatar-image"
             src="${currentUser.avatar}"
             alt="${currentUser.name}"
           />
         </div>
-        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-badges="${(currentUser.badges || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">${currentUser.name}</h3>
+        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-token="${currentUser.token}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-bio="${currentUser.bio || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-badges="${(currentUser.badges || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">${currentUser.name}</h3>
         <p class="user-url">www.gamehuntress.com</p>
         <ul class="profile-stats">
           <li class="profile-stat"><span class="stat-value">930</span><span class="stat-label">Posts</span></li>

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -16,7 +16,7 @@ export default async function init({ hub, root, utils }) {
 
   root.innerHTML = `
     <nav class="navigation-small" data-role="small">
-      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">
+      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">
         <img
           class="avatar-image"
           src="${currentUser.avatar}"
@@ -44,14 +44,14 @@ export default async function init({ hub, root, utils }) {
           alt=""
           aria-hidden="true"
         />
-        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">
+        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">
           <img
             class="avatar-image"
             src="${currentUser.avatar}"
             alt="${currentUser.name}"
           />
         </div>
-        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">${currentUser.name}</h3>
+        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">${currentUser.name}</h3>
         <p class="user-url">www.gamehuntress.com</p>
         <ul class="profile-stats">
           <li class="profile-stat"><span class="stat-value">930</span><span class="stat-label">Posts</span></li>

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -90,7 +90,7 @@ export default async function init({ hub, root, utils }) {
     e.preventDefault();
     const mod = link.getAttribute('data-module');
     if (mod === 'profile') {
-      window.LoadMainModule('profile', { user: currentUser });
+      hub.api['profile-overlay'].show(currentUser);
     } else if (mod) {
       window.LoadMainModule(mod);
     }
@@ -103,7 +103,7 @@ export default async function init({ hub, root, utils }) {
     (e) => {
       e.preventDefault();
       e.stopPropagation();
-      window.LoadMainModule('profile', { user: currentUser });
+      hub.api['profile-overlay'].show(currentUser);
     }
   );
 

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -90,22 +90,16 @@ export default async function init({ hub, root, utils }) {
     e.preventDefault();
     const mod = link.getAttribute('data-module');
     if (mod === 'profile') {
-      hub.api['profile-overlay'].show(currentUser);
+      const rect = link.getBoundingClientRect();
+      hub.api['mini-profile'].show(
+        currentUser,
+        rect.left + rect.width / 2 + window.scrollX,
+        rect.bottom + window.scrollY
+      );
     } else if (mod) {
       window.LoadMainModule(mod);
     }
   });
-
-  utils.delegate(
-    root,
-    'click',
-    '.navigation-avatar, .navigation-large-profile .avatar-wrap, .navigation-large-profile .user-name',
-    (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      hub.api['profile-overlay'].show(currentUser);
-    }
-  );
 
   // Tooltip handling for compact navigation
   let tooltip;

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -96,9 +96,16 @@ export default async function init({ hub, root, utils }) {
     }
   });
 
-  utils.delegate(root, 'click', '.navigation-avatar', (e) => {
-    e.preventDefault();
-  });
+  utils.delegate(
+    root,
+    'click',
+    '.navigation-avatar, .navigation-large-profile .avatar-wrap, .navigation-large-profile .user-name',
+    (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      window.LoadMainModule('profile', { user: currentUser });
+    }
+  );
 
   // Tooltip handling for compact navigation
   let tooltip;

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -16,7 +16,7 @@ export default async function init({ hub, root, utils }) {
 
   root.innerHTML = `
     <nav class="navigation-small" data-role="small">
-      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">
+      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">
         <img
           class="avatar-image"
           src="${currentUser.avatar}"
@@ -44,14 +44,14 @@ export default async function init({ hub, root, utils }) {
           alt=""
           aria-hidden="true"
         />
-        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">
+        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">
           <img
             class="avatar-image"
             src="${currentUser.avatar}"
             alt="${currentUser.name}"
           />
         </div>
-        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">${currentUser.name}</h3>
+        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">${currentUser.name}</h3>
         <p class="user-url">www.gamehuntress.com</p>
         <ul class="profile-stats">
           <li class="profile-stat"><span class="stat-value">930</span><span class="stat-label">Posts</span></li>

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -16,7 +16,7 @@ export default async function init({ hub, root, utils }) {
 
   root.innerHTML = `
     <nav class="navigation-small" data-role="small">
-      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');">
+      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}">
         <img
           class="avatar-image"
           src="${currentUser.avatar}"
@@ -44,14 +44,14 @@ export default async function init({ hub, root, utils }) {
           alt=""
           aria-hidden="true"
         />
-        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');">
+        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}">
           <img
             class="avatar-image"
             src="${currentUser.avatar}"
             alt="${currentUser.name}"
           />
         </div>
-        <h3 class="user-name">${currentUser.name}</h3>
+        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}">${currentUser.name}</h3>
         <p class="user-url">www.gamehuntress.com</p>
         <ul class="profile-stats">
           <li class="profile-stat"><span class="stat-value">930</span><span class="stat-label">Posts</span></li>
@@ -98,7 +98,6 @@ export default async function init({ hub, root, utils }) {
 
   utils.delegate(root, 'click', '.navigation-avatar', (e) => {
     e.preventDefault();
-    window.LoadMainModule('profile', { user: currentUser });
   });
 
   // Tooltip handling for compact navigation

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -16,7 +16,7 @@ export default async function init({ hub, root, utils }) {
 
   root.innerHTML = `
     <nav class="navigation-small" data-role="small">
-      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">
+      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-badges="${(currentUser.badges || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">
         <img
           class="avatar-image"
           src="${currentUser.avatar}"
@@ -44,14 +44,14 @@ export default async function init({ hub, root, utils }) {
           alt=""
           aria-hidden="true"
         />
-        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">
+        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-badges="${(currentUser.badges || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">
           <img
             class="avatar-image"
             src="${currentUser.avatar}"
             alt="${currentUser.name}"
           />
         </div>
-        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">${currentUser.name}</h3>
+        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-slug="${currentUser.slug}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}" data-profile-badges="${(currentUser.badges || []).join(',')}" data-profile-streaming="${currentUser.streaming ? 'true' : 'false'}">${currentUser.name}</h3>
         <p class="user-url">www.gamehuntress.com</p>
         <ul class="profile-stats">
           <li class="profile-stat"><span class="stat-value">930</span><span class="stat-label">Posts</span></li>

--- a/module/navigation/navigation.js
+++ b/module/navigation/navigation.js
@@ -16,7 +16,7 @@ export default async function init({ hub, root, utils }) {
 
   root.innerHTML = `
     <nav class="navigation-small" data-role="small">
-      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}">
+      <a href="#" class="navigation-avatar avatar-wrap" style="--avi-width:48px; --avi-height:48px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">
         <img
           class="avatar-image"
           src="${currentUser.avatar}"
@@ -44,14 +44,14 @@ export default async function init({ hub, root, utils }) {
           alt=""
           aria-hidden="true"
         />
-        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}">
+        <div class="avatar-wrap" style="--avi-width:90px; --avi-height:90px; --frame:url('${currentUser.frame}');" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">
           <img
             class="avatar-image"
             src="${currentUser.avatar}"
             alt="${currentUser.name}"
           />
         </div>
-        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}">${currentUser.name}</h3>
+        <h3 class="user-name" data-profile-name="${currentUser.name}" data-profile-avatar="${currentUser.avatar}" data-profile-banner="${currentUser.banner}" data-profile-accent="${currentUser.accent}" data-profile-frame="${currentUser.frame}" data-profile-about="${currentUser.about || ''}" data-profile-since="${currentUser.memberSince || ''}" data-profile-connections="${(currentUser.connections || []).join(',')}">${currentUser.name}</h3>
         <p class="user-url">www.gamehuntress.com</p>
         <ul class="profile-stats">
           <li class="profile-stat"><span class="stat-value">930</span><span class="stat-label">Posts</span></li>

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -1,0 +1,94 @@
+module[data-module="profile-overlay"] .profile-overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999;
+}
+
+module[data-module="profile-overlay"] .profile-overlay.hidden {
+  display: none;
+}
+
+module[data-module="profile-overlay"] .po-card {
+  background: #fff;
+  color: #333;
+  width: 600px;
+  max-width: 100%;
+  border-radius: 8px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  position: relative;
+  overflow: hidden;
+}
+
+module[data-module="profile-overlay"] .po-banner {
+  grid-column: 1 / -1;
+  height: 120px;
+  background-size: cover;
+  background-position: center;
+}
+
+module[data-module="profile-overlay"] .po-content {
+  padding: 72px 24px 24px;
+}
+
+module[data-module="profile-overlay"] .po-avatar {
+  position: absolute;
+  top: 72px;
+  left: 24px;
+  width: 96px;
+  height: 96px;
+  border-radius: 50%;
+  overflow: hidden;
+  box-shadow: 0 0 0 4px var(--accent, #5865f2);
+  background: var(--frame) center/cover no-repeat;
+}
+
+module[data-module="profile-overlay"] .po-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+module[data-module="profile-overlay"] .po-name {
+  margin: 0 0 0 112px;
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+module[data-module="profile-overlay"] .po-tabs {
+  border-left: 1px solid #eee;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+module[data-module="profile-overlay"] .po-tab {
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 8px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+module[data-module="profile-overlay"] .po-tab.active {
+  background: var(--accent, #5865f2);
+  color: #fff;
+}
+
+module[data-module="profile-overlay"] .po-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: transparent;
+  border: none;
+  font-size: 24px;
+  line-height: 1;
+  cursor: pointer;
+  color: #666;
+}

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -36,8 +36,10 @@ module[data-module="profile-overlay"] .po-left {
 
 module[data-module="profile-overlay"] .po-banner {
   height: 120px;
+  background-color: #f3f4f6;
+  background-position: center top;
   background-size: cover;
-  background-position: center;
+  background-repeat: no-repeat;
   position: relative;
 }
 

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -274,3 +274,48 @@ module[data-module="profile-overlay"] .po-topic-perms {
   color: #6b7280;
   font-size: 0.875rem;
 }
+
+module[data-module="profile-overlay"] .po-badge-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+module[data-module="profile-overlay"] .po-badge-item {
+  display: flex;
+  align-items: center;
+  background: #f9fafb;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 12px;
+}
+
+module[data-module="profile-overlay"] .po-badge-item img {
+  width: 48px;
+  height: 48px;
+  margin-right: 12px;
+}
+
+module[data-module="profile-overlay"] .po-badge-info {
+  display: flex;
+  flex-direction: column;
+}
+
+module[data-module="profile-overlay"] .po-badge-name {
+  font-weight: 600;
+  margin: 0;
+}
+
+module[data-module="profile-overlay"] .po-badge-desc {
+  font-size: 0.875rem;
+  color: #374151;
+  margin: 4px 0;
+}
+
+module[data-module="profile-overlay"] .po-badge-meta {
+  font-size: 0.75rem;
+  color: #6b7280;
+}

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -131,6 +131,7 @@ module[data-module="profile-overlay"] .po-action {
   font-size: 0.875rem;
   border-radius: 6px;
   cursor: pointer;
+  width: auto;
 }
 
 module[data-module="profile-overlay"] .po-action svg {
@@ -237,6 +238,7 @@ module[data-module="profile-overlay"] .po-activity-list .act-btn {
   font-size: 0.75rem;
   border-radius: 4px;
   cursor: pointer;
+  width: auto;
 }
 
 module[data-module="profile-overlay"] .po-right {

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -127,7 +127,7 @@ module[data-module="profile-overlay"] .po-action {
   background: var(--accent, #5865f2);
   border: none;
   color: #ffffff;
-  padding: 6px 8px;
+  padding: 4px 6px;
   font-size: 0.875rem;
   border-radius: 6px;
   cursor: pointer;

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -191,6 +191,20 @@ module[data-module="profile-overlay"] .po-note-text {
   color: #6b7280;
 }
 
+module[data-module="profile-overlay"] .po-activity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+module[data-module="profile-overlay"] .po-activity-list li {
+  font-size: 0.875rem;
+  color: #1f2937;
+}
+
 module[data-module="profile-overlay"] .po-right {
   background: #ffffff;
   padding: 16px 24px;

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -22,7 +22,7 @@ module[data-module="profile-overlay"] .po-card {
   border-radius: 8px;
   box-shadow: 0 16px 40px rgba(0,0,0,.2);
   display: grid;
-  grid-template-columns: 260px 1fr;
+  grid-template-columns: 340px 1fr;
   overflow: hidden;
   position: relative;
 }
@@ -30,6 +30,8 @@ module[data-module="profile-overlay"] .po-card {
 module[data-module="profile-overlay"] .po-left {
   background: #f9fafb;
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 module[data-module="profile-overlay"] .po-banner {
@@ -48,8 +50,8 @@ module[data-module="profile-overlay"] .po-left-body {
   margin-top: -48px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  text-align: center;
+  align-items: flex-start;
+  text-align: left;
 }
 
 module[data-module="profile-overlay"] .po-avatar {
@@ -71,7 +73,53 @@ module[data-module="profile-overlay"] .po-name {
   margin-top: 12px;
   font-size: 1.25rem;
   font-weight: 700;
-  text-align: center;
+  text-align: left;
+}
+
+module[data-module="profile-overlay"] .po-edit {
+  margin-top: 8px;
+  background: #e5e7eb;
+  border: 1px solid #d1d5db;
+  color: #1f2937;
+  padding: 4px 8px;
+  font-size: 0.875rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+module[data-module="profile-overlay"] .po-about {
+  margin-top: 16px;
+  font-size: 0.875rem;
+  color: #374151;
+  white-space: pre-wrap;
+}
+
+module[data-module="profile-overlay"] .po-section {
+  margin-top: 24px;
+  width: 100%;
+}
+
+module[data-module="profile-overlay"] .po-section h3 {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #6b7280;
+  margin-bottom: 8px;
+}
+
+module[data-module="profile-overlay"] .po-member-date {
+  font-size: 0.875rem;
+  color: #1f2937;
+}
+
+module[data-module="profile-overlay"] .po-conn-list {
+  display: flex;
+  gap: 8px;
+}
+
+module[data-module="profile-overlay"] .po-conn-list img {
+  width: 24px;
+  height: 24px;
 }
 
 module[data-module="profile-overlay"] .po-right {
@@ -79,6 +127,7 @@ module[data-module="profile-overlay"] .po-right {
   padding: 16px 24px;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 module[data-module="profile-overlay"] .po-tabs {
@@ -113,4 +162,43 @@ module[data-module="profile-overlay"] .po-close {
   line-height: 1;
   cursor: pointer;
   color: #6b7280;
+}
+
+module[data-module="profile-overlay"] .po-panel {
+  flex: 1;
+  overflow-y: auto;
+}
+
+module[data-module="profile-overlay"] .po-activity {
+  text-align: center;
+  color: #6b7280;
+  padding: 40px 0;
+}
+
+module[data-module="profile-overlay"] .po-activity-head {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #1f2937;
+}
+
+module[data-module="profile-overlay"] .po-activity-sub {
+  font-size: 0.875rem;
+  margin-top: 4px;
+}
+
+module[data-module="profile-overlay"] .po-activity-actions {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 24px;
+}
+
+module[data-module="profile-overlay"] .po-btn {
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-weight: 600;
+  color: #1f2937;
+  cursor: pointer;
 }

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -256,3 +256,21 @@ module[data-module="profile-overlay"] .po-empty {
   color: #6b7280;
   padding: 40px 0;
 }
+
+module[data-module="profile-overlay"] .po-topic-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+module[data-module="profile-overlay"] .po-topic-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 8px 0;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+module[data-module="profile-overlay"] .po-topic-perms {
+  color: #6b7280;
+  font-size: 0.875rem;
+}

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -189,10 +189,6 @@ module[data-module="profile-overlay"] .po-conn-list img {
   height: 24px;
 }
 
-module[data-module="profile-overlay"] .po-note-text {
-  font-size: 0.875rem;
-  color: #6b7280;
-}
 
 module[data-module="profile-overlay"] .po-activity-list {
   display: flex;

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -228,6 +228,17 @@ module[data-module="profile-overlay"] .po-activity-list .act-info span {
   color: #6b7280;
 }
 
+module[data-module="profile-overlay"] .po-activity-list .act-btn {
+  margin-left: auto;
+  background: var(--accent, #5865f2);
+  border: none;
+  color: #ffffff;
+  padding: 4px 8px;
+  font-size: 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
 module[data-module="profile-overlay"] .po-right {
   background: #ffffff;
   padding: 16px 24px;

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -131,10 +131,6 @@ module[data-module="profile-overlay"] .po-action {
   cursor: pointer;
 }
 
-module[data-module="profile-overlay"] .po-action.icon-only {
-  padding: 6px;
-}
-
 module[data-module="profile-overlay"] .po-action svg {
   width: 16px;
   height: 16px;
@@ -241,36 +237,8 @@ module[data-module="profile-overlay"] .po-panel.active {
   display: block;
 }
 
-module[data-module="profile-overlay"] .po-activity {
+module[data-module="profile-overlay"] .po-empty {
   text-align: center;
   color: #6b7280;
   padding: 40px 0;
-}
-
-module[data-module="profile-overlay"] .po-activity-head {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #1f2937;
-}
-
-module[data-module="profile-overlay"] .po-activity-sub {
-  font-size: 0.875rem;
-  margin-top: 4px;
-}
-
-module[data-module="profile-overlay"] .po-activity-actions {
-  display: flex;
-  justify-content: center;
-  gap: 12px;
-  margin-top: 24px;
-}
-
-module[data-module="profile-overlay"] .po-btn {
-  background: #f3f4f6;
-  border: 1px solid #e5e7eb;
-  padding: 8px 12px;
-  border-radius: 4px;
-  font-weight: 600;
-  color: #1f2937;
-  cursor: pointer;
 }

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -50,8 +50,8 @@ module[data-module="profile-overlay"] .po-left-body {
   margin-top: -48px;
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  text-align: left;
+  align-items: center;
+  text-align: center;
 }
 
 module[data-module="profile-overlay"] .po-avatar {
@@ -95,7 +95,7 @@ module[data-module="profile-overlay"] .po-name {
   margin-top: 12px;
   font-size: 1.25rem;
   font-weight: 700;
-  text-align: left;
+  text-align: center;
 }
 
 module[data-module="profile-overlay"] .po-edit {
@@ -110,7 +110,7 @@ module[data-module="profile-overlay"] .po-edit {
 }
 
 module[data-module="profile-overlay"] .po-about {
-  margin-top: 16px;
+  margin-top: 0;
   font-size: 0.875rem;
   color: #374151;
   white-space: pre-wrap;
@@ -119,6 +119,7 @@ module[data-module="profile-overlay"] .po-about {
 module[data-module="profile-overlay"] .po-section {
   margin-top: 24px;
   width: 100%;
+  text-align: left;
 }
 
 module[data-module="profile-overlay"] .po-section h3 {
@@ -142,6 +143,11 @@ module[data-module="profile-overlay"] .po-conn-list {
 module[data-module="profile-overlay"] .po-conn-list img {
   width: 24px;
   height: 24px;
+}
+
+module[data-module="profile-overlay"] .po-note-text {
+  font-size: 0.875rem;
+  color: #6b7280;
 }
 
 module[data-module="profile-overlay"] .po-right {
@@ -173,16 +179,21 @@ module[data-module="profile-overlay"] .po-tab.active {
   border-color: var(--accent, #5865f2);
 }
 
-module[data-module="profile-overlay"] .po-close {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  background: transparent;
-  border: none;
-  font-size: 24px;
-  line-height: 1;
+module[data-module="profile-overlay"] .po-footer {
+  margin-top: 16px;
+  border-top: 1px solid #e5e7eb;
+  padding-top: 16px;
+  text-align: right;
+}
+
+module[data-module="profile-overlay"] .po-footer .po-close {
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-weight: 600;
+  color: #1f2937;
   cursor: pointer;
-  color: #6b7280;
 }
 
 module[data-module="profile-overlay"] .po-panels {

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -112,15 +112,32 @@ module[data-module="profile-overlay"] .po-tagline {
   color: #6b7280;
 }
 
-module[data-module="profile-overlay"] .po-edit {
+module[data-module="profile-overlay"] .po-actions {
   margin-top: 8px;
-  background: #e5e7eb;
-  border: 1px solid #d1d5db;
+  display: flex;
+  gap: 8px;
+}
+
+module[data-module="profile-overlay"] .po-action {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: #f3f4f6;
+  border: 1px solid #e5e7eb;
   color: #1f2937;
-  padding: 4px 8px;
+  padding: 6px 8px;
   font-size: 0.875rem;
-  border-radius: 4px;
+  border-radius: 6px;
   cursor: pointer;
+}
+
+module[data-module="profile-overlay"] .po-action.icon-only {
+  padding: 6px;
+}
+
+module[data-module="profile-overlay"] .po-action svg {
+  width: 16px;
+  height: 16px;
 }
 
 module[data-module="profile-overlay"] .po-about {

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -55,18 +55,40 @@ module[data-module="profile-overlay"] .po-left-body {
 }
 
 module[data-module="profile-overlay"] .po-avatar {
+  position: relative;
   width: 96px;
   height: 96px;
   border-radius: 50%;
-  overflow: hidden;
-  box-shadow: 0 0 0 6px #ffffff;
-  background: var(--frame) center/cover no-repeat;
+  overflow: visible;
+  isolation: isolate;
+}
+
+module[data-module="profile-overlay"] .po-avatar::before {
+  content: "";
+  position: absolute;
+  inset: -6px;
+  border-radius: 50%;
+  background: #ffffff;
+  z-index: 0;
 }
 
 module[data-module="profile-overlay"] .po-avatar img {
+  position: relative;
+  z-index: 1;
   width: 100%;
   height: 100%;
+  border-radius: 50%;
   object-fit: cover;
+  display: block;
+}
+
+module[data-module="profile-overlay"] .po-avatar::after {
+  content: "";
+  position: absolute;
+  inset: -18%;
+  background: var(--frame, none) center/contain no-repeat;
+  pointer-events: none;
+  z-index: 2;
 }
 
 module[data-module="profile-overlay"] .po-name {
@@ -127,7 +149,6 @@ module[data-module="profile-overlay"] .po-right {
   padding: 16px 24px;
   display: flex;
   flex-direction: column;
-  position: relative;
 }
 
 module[data-module="profile-overlay"] .po-tabs {
@@ -164,9 +185,18 @@ module[data-module="profile-overlay"] .po-close {
   color: #6b7280;
 }
 
-module[data-module="profile-overlay"] .po-panel {
+module[data-module="profile-overlay"] .po-panels {
   flex: 1;
   overflow-y: auto;
+}
+
+module[data-module="profile-overlay"] .po-panel {
+  display: none;
+  height: 100%;
+}
+
+module[data-module="profile-overlay"] .po-panel.active {
+  display: block;
 }
 
 module[data-module="profile-overlay"] .po-activity {

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -1,6 +1,9 @@
 module[data-module="profile-overlay"] .profile-overlay {
-  position: absolute;
-  inset: 0;
+  position: fixed;
+  top: 80px;
+  left: 0;
+  right: 0;
+  bottom: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -12,38 +15,45 @@ module[data-module="profile-overlay"] .profile-overlay.hidden {
 }
 
 module[data-module="profile-overlay"] .po-card {
-  background: #fff;
-  color: #333;
-  width: 600px;
+  background: #ffffff;
+  color: #1f2937;
+  width: 720px;
   max-width: 100%;
   border-radius: 8px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 16px 40px rgba(0,0,0,.2);
   display: grid;
-  grid-template-columns: 2fr 1fr;
-  position: relative;
+  grid-template-columns: 260px 1fr;
   overflow: hidden;
+  position: relative;
+}
+
+module[data-module="profile-overlay"] .po-left {
+  background: #f9fafb;
+  position: relative;
 }
 
 module[data-module="profile-overlay"] .po-banner {
-  grid-column: 1 / -1;
   height: 120px;
   background-size: cover;
   background-position: center;
 }
 
-module[data-module="profile-overlay"] .po-content {
-  padding: 72px 24px 24px;
+module[data-module="profile-overlay"] .po-accent {
+  height: 4px;
+  background: var(--accent, #5865f2);
+}
+
+module[data-module="profile-overlay"] .po-left-body {
+  padding: 0 16px 24px;
+  margin-top: -48px;
 }
 
 module[data-module="profile-overlay"] .po-avatar {
-  position: absolute;
-  top: 72px;
-  left: 24px;
   width: 96px;
   height: 96px;
   border-radius: 50%;
   overflow: hidden;
-  box-shadow: 0 0 0 4px var(--accent, #5865f2);
+  box-shadow: 0 0 0 6px #ffffff;
   background: var(--frame) center/cover no-repeat;
 }
 
@@ -54,31 +64,38 @@ module[data-module="profile-overlay"] .po-avatar img {
 }
 
 module[data-module="profile-overlay"] .po-name {
-  margin: 0 0 0 112px;
-  font-size: 1.5rem;
-  font-weight: 600;
+  margin-top: 12px;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+module[data-module="profile-overlay"] .po-right {
+  background: #ffffff;
+  padding: 16px 24px;
+  display: flex;
+  flex-direction: column;
 }
 
 module[data-module="profile-overlay"] .po-tabs {
-  border-left: 1px solid #eee;
-  padding: 24px;
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  gap: 16px;
+  border-bottom: 1px solid #e5e7eb;
+  margin-bottom: 16px;
 }
 
 module[data-module="profile-overlay"] .po-tab {
   background: none;
   border: none;
-  text-align: left;
-  padding: 8px 12px;
-  border-radius: 4px;
+  padding: 0 0 8px;
+  font-weight: 600;
+  color: #6b7280;
   cursor: pointer;
+  border-bottom: 2px solid transparent;
 }
 
 module[data-module="profile-overlay"] .po-tab.active {
-  background: var(--accent, #5865f2);
-  color: #fff;
+  color: #111827;
+  border-color: var(--accent, #5865f2);
 }
 
 module[data-module="profile-overlay"] .po-close {
@@ -90,5 +107,5 @@ module[data-module="profile-overlay"] .po-close {
   font-size: 24px;
   line-height: 1;
   cursor: pointer;
-  color: #666;
+  color: #6b7280;
 }

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -122,9 +122,9 @@ module[data-module="profile-overlay"] .po-action {
   display: flex;
   align-items: center;
   gap: 4px;
-  background: #f3f4f6;
-  border: 1px solid #e5e7eb;
-  color: #1f2937;
+  background: var(--accent, #5865f2);
+  border: none;
+  color: #ffffff;
   padding: 6px 8px;
   font-size: 0.875rem;
   border-radius: 6px;
@@ -134,6 +134,18 @@ module[data-module="profile-overlay"] .po-action {
 module[data-module="profile-overlay"] .po-action svg {
   width: 16px;
   height: 16px;
+}
+
+module[data-module="profile-overlay"] .po-badges {
+  margin-top: 4px;
+  display: none;
+  gap: 4px;
+  justify-content: center;
+}
+
+module[data-module="profile-overlay"] .po-badges img {
+  width: 24px;
+  height: 24px;
 }
 
 module[data-module="profile-overlay"] .po-about {

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -38,6 +38,14 @@ module[data-module="profile-overlay"] .po-banner {
   height: 120px;
   background-size: cover;
   background-position: center;
+  position: relative;
+}
+
+module[data-module="profile-overlay"] .po-banner::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(255,255,255,0) 20%, rgba(255,255,255,.35) 100%);
 }
 
 module[data-module="profile-overlay"] .po-accent {
@@ -96,6 +104,12 @@ module[data-module="profile-overlay"] .po-name {
   font-size: 1.25rem;
   font-weight: 700;
   text-align: center;
+}
+
+module[data-module="profile-overlay"] .po-tagline {
+  margin-top: 4px;
+  font-size: 0.875rem;
+  color: #6b7280;
 }
 
 module[data-module="profile-overlay"] .po-edit {

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -118,25 +118,28 @@ module[data-module="profile-overlay"] .po-actions {
   margin-top: 8px;
   display: flex;
   gap: 8px;
+  width: 100%;
 }
 
 module[data-module="profile-overlay"] .po-action {
+  flex: 1 1 0;
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
   background: var(--accent, #5865f2);
   border: none;
   color: #ffffff;
-  padding: 4px 6px;
-  font-size: 0.875rem;
+  padding: 6px 4px;
+  font-size: 0.75rem;
   border-radius: 6px;
   cursor: pointer;
-  width: auto;
+  text-align: center;
 }
 
 module[data-module="profile-overlay"] .po-action svg {
-  width: 16px;
-  height: 16px;
+  width: 20px;
+  height: 20px;
 }
 
 module[data-module="profile-overlay"] .po-badges {

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -46,6 +46,10 @@ module[data-module="profile-overlay"] .po-accent {
 module[data-module="profile-overlay"] .po-left-body {
   padding: 0 16px 24px;
   margin-top: -48px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
 module[data-module="profile-overlay"] .po-avatar {
@@ -67,6 +71,7 @@ module[data-module="profile-overlay"] .po-name {
   margin-top: 12px;
   font-size: 1.25rem;
   font-weight: 700;
+  text-align: center;
 }
 
 module[data-module="profile-overlay"] .po-right {

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -118,23 +118,22 @@ module[data-module="profile-overlay"] .po-actions {
   margin-top: 8px;
   display: flex;
   gap: 8px;
-  width: 100%;
+  justify-content: center;
 }
 
 module[data-module="profile-overlay"] .po-action {
-  flex: 1 1 0;
+  flex: 0 0 40px;
+  width: 40px;
+  height: 40px;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 2px;
+  justify-content: center;
   background: var(--accent, #5865f2);
   border: none;
   color: #ffffff;
-  padding: 6px 4px;
-  font-size: 0.75rem;
+  padding: 0;
   border-radius: 6px;
   cursor: pointer;
-  text-align: center;
 }
 
 module[data-module="profile-overlay"] .po-action svg {

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -37,7 +37,7 @@ module[data-module="profile-overlay"] .po-left {
 module[data-module="profile-overlay"] .po-banner {
   height: 120px;
   background-color: #f3f4f6;
-  background-position: center top;
+  background-position: right top;
   background-size: cover;
   background-repeat: no-repeat;
   position: relative;

--- a/module/profile-overlay/profile-overlay.css
+++ b/module/profile-overlay/profile-overlay.css
@@ -201,8 +201,31 @@ module[data-module="profile-overlay"] .po-activity-list {
 }
 
 module[data-module="profile-overlay"] .po-activity-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #f3f4f6;
+  border-radius: 4px;
+  padding: 6px 8px;
   font-size: 0.875rem;
   color: #1f2937;
+}
+
+module[data-module="profile-overlay"] .po-activity-list img {
+  width: 40px;
+  height: 24px;
+  object-fit: cover;
+  border-radius: 2px;
+}
+
+module[data-module="profile-overlay"] .po-activity-list .act-info {
+  display: flex;
+  flex-direction: column;
+}
+
+module[data-module="profile-overlay"] .po-activity-list .act-info span {
+  font-size: 0.75rem;
+  color: #6b7280;
 }
 
 module[data-module="profile-overlay"] .po-right {

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -3,14 +3,16 @@ import { getUserByToken } from '../users.js';
 export default async function init({ hub, root, utils }) {
   const loggedIn = await fetch('/data/logged-in.json').then(r => r.json()).catch(() => null);
 
-  const icons = {
-    follow:
-      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 7a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"/><path fill-rule="evenodd" d="M12 14a7 7 0 0 0-7 7 .75.75 0 0 0 1.5 0 5.5 5.5 0 0 1 11 0 .75.75 0 0 0 1.5 0 7 7 0 0 0-7-7Z" clip-rule="evenodd"/><path d="M19 7a1 1 0 1 0 0-2h-1V4a1 1 0 1 0-2 0v1h-1a1 1 0 1 0 0 2h1v1a1 1 0 1 0 2 0V7h1Z"/></svg>',
-    support:
-      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M11.645 20.353a.75.75 0 0 0 .71 0 45.956 45.956 0 0 0 1.035-.62c1.588-.977 3.267-2.015 4.825-3.152C21.247 14.73 23 12.537 23 9.943 23 7.206 20.955 5 18.352 5c-1.542 0-3.01.876-3.708 2.18a.75.75 0 0 1-1.288 0C12.655 5.876 11.187 5 9.645 5 7.043 5 5 7.206 5 9.943c0 2.594 1.753 4.786 3.785 6.638 1.558 1.137 3.237 2.175 4.825 3.152.345.212.689.42 1.035.62Z" clip-rule="evenodd"/></svg>',
-    shop:
-      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 6v.75H5.513c-.96 0-1.764.724-1.865 1.679l-1.263 12A1.875 1.875 0 0 0 4.25 22.5h15.5a1.875 1.875 0 0 0 1.865-2.071l-1.263-12a1.875 1.875 0 0 0-1.865-1.679H16.5V6a4.5 4.5 0 1 0-9 0ZM12 3a3 3 0 0 0-3 3v.75h6V6a3 3 0 0 0-3-3Zm-3 8.25a3 3 0 1 0 6 0v-.75a.75.75 0 0 1 1.5 0v.75a4.5 4.5 0 1 1-9 0v-.75a.75.75 0 0 1 1.5 0v.75Z" clip-rule="evenodd"/></svg>'
-  };
+    const icons = {
+      follow:
+        '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 7a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"/><path fill-rule="evenodd" d="M12 14a7 7 0 0 0-7 7 .75.75 0 0 0 1.5 0 5.5 5.5 0 0 1 11 0 .75.75 0 0 0 1.5 0 7 7 0 0 0-7-7Z" clip-rule="evenodd"/><path d="M19 7a1 1 0 1 0 0-2h-1V4a1 1 0 1 0-2 0v1h-1a1 1 0 1 0 0 2h1v1a1 1 0 1 0 2 0V7h1Z"/></svg>',
+      support:
+        '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M11.645 20.353a.75.75 0 0 0 .71 0 45.956 45.956 0 0 0 1.035-.62c1.588-.977 3.267-2.015 4.825-3.152C21.247 14.73 23 12.537 23 9.943 23 7.206 20.955 5 18.352 5c-1.542 0-3.01.876-3.708 2.18a.75.75 0 0 1-1.288 0C12.655 5.876 11.187 5 9.645 5 7.043 5 5 7.206 5 9.943c0 2.594 1.753 4.786 3.785 6.638 1.558 1.137 3.237 2.175 4.825 3.152.345.212.689.42 1.035.62Z" clip-rule="evenodd"/></svg>',
+      shop:
+        '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 6v.75H5.513c-.964 0-1.764.724-1.865 1.679l-1.263 12A1.875 1.875 0 0 0 4.25 22.5h15.5a1.875 1.875 0 0 0 1.865-2.071l-1.263-12a1.875 1.875 0 0 0-1.865-1.679H16.5V6a4.5 4.5 0 1 0-9 0ZM12 3a3 3 0 0 0-3 3v.75h6V6a3 3 0 0 0-3-3Zm-3 8.25a3 3 0 1 0 6 0v-.75a.75.75 0 0 1 1.5 0v.75a4.5 4.5 0 1 1-9 0v-.75a.75.75 0 0 1 1.5 0v.75Z" clip-rule="evenodd"/></svg>',
+      stream:
+        '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M5 3.5v17l14-8.5-14-8.5Z"/></svg>'
+    };
 
   root.innerHTML = `
     <div class="profile-overlay hidden" role="dialog" aria-modal="true">
@@ -164,10 +166,13 @@ export default async function init({ hub, root, utils }) {
     actions.innerHTML = '';
     const isSelf = user.token === loggedIn;
     if (!isSelf) {
-      actions.innerHTML += `<button class="po-action follow">${icons.follow}<span>Follow</span></button>`;
-      actions.innerHTML += `<button class="po-action support">${icons.support}<span>Support</span></button>`;
+      actions.innerHTML += `<button class="po-action follow" aria-label="Follow">${icons.follow}</button>`;
+      actions.innerHTML += `<button class="po-action support" aria-label="Support">${icons.support}</button>`;
     }
-    actions.innerHTML += `<button class="po-action shop">${icons.shop}<span>Shop</span></button>`;
+    actions.innerHTML += `<button class="po-action shop" aria-label="Shop">${icons.shop}</button>`;
+    if (user.streaming) {
+      actions.innerHTML += `<button class="po-action stream" aria-label="View Stream">${icons.stream}</button>`;
+    }
     if (user.badges && user.badges.length) {
       badgesEl.innerHTML = user.badges.slice(0,5).map((b) => `<img src="${b}" alt="badge" />`).join('');
       badgesEl.style.display = 'flex';

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -20,6 +20,7 @@ export default async function init({ hub, root, utils }) {
             <div class="po-avatar"><img alt="" /></div>
             <h2 class="po-name"></h2>
             <p class="po-tagline"></p>
+            <div class="po-badges"></div>
             <div class="po-actions"></div>
             <div class="po-section po-about-section">
               <h3>About Me</h3>
@@ -75,6 +76,7 @@ export default async function init({ hub, root, utils }) {
   const memberDateEl = overlay.querySelector('.po-member-date');
   const connList = overlay.querySelector('.po-conn-list');
   const actions = overlay.querySelector('.po-actions');
+  const badgesEl = overlay.querySelector('.po-badges');
   const closeBtn = overlay.querySelector('.po-close');
   const tabs = overlay.querySelectorAll('.po-tab');
   const panels = overlay.querySelectorAll('.po-panel');
@@ -103,6 +105,13 @@ export default async function init({ hub, root, utils }) {
       actions.innerHTML += `<button class="po-action support">${icons.support}<span>Support</span></button>`;
     }
     actions.innerHTML += `<button class="po-action shop">${icons.shop}<span>Shop</span></button>`;
+    if (user.badges && user.badges.length) {
+      badgesEl.innerHTML = user.badges.slice(0,5).map((b) => `<img src="${b}" alt="badge" />`).join('');
+      badgesEl.style.display = 'flex';
+    } else {
+      badgesEl.innerHTML = '';
+      badgesEl.style.display = 'none';
+    }
     if (user.memberSince) {
       memberDateEl.textContent = user.memberSince;
       memberDateEl.closest('.po-member').style.display = 'block';

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -93,6 +93,30 @@ export default async function init({ hub, root, utils }) {
   const topicsPanel = overlay.querySelector('[data-panel="topics"]');
   const badgesPanel = overlay.querySelector('[data-panel="badges"]');
 
+  let tooltip;
+  function showTooltip(el) {
+    const title = el.getAttribute('aria-label');
+    if (!title) return;
+    tooltip = document.createElement('div');
+    tooltip.className = 'navigation-small-tooltip';
+    tooltip.textContent = title;
+    tooltip.style.zIndex = '2100';
+    document.body.appendChild(tooltip);
+    const rect = el.getBoundingClientRect();
+    tooltip.style.top = `${rect.top + rect.height / 2}px`;
+    tooltip.style.left = `${rect.right}px`;
+    requestAnimationFrame(() => tooltip.classList.add('visible'));
+  }
+  function hideTooltip() {
+    if (tooltip) {
+      tooltip.remove();
+      tooltip = null;
+    }
+  }
+
+  utils.delegate(actions, 'mouseover', '.po-action', (e, el) => showTooltip(el));
+  utils.delegate(actions, 'mouseout', '.po-action', hideTooltip);
+
   function activityCards(user = {}) {
     const cards = [];
     const status = user.status || {};
@@ -266,6 +290,7 @@ export default async function init({ hub, root, utils }) {
   }
 
   function hide() {
+    hideTooltip();
     overlay.classList.add('hidden');
     overlay.classList.remove('visible');
   }

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -102,16 +102,20 @@ export default async function init({ hub, root, utils }) {
           s.thumbnailId ? `<img src="${s.thumbnailId}" alt="" />` : ''
         }<div class="act-info"><strong>${s.title || 'Streaming'}</strong>${
           s.viewers ? `<span>${s.viewers} viewers</span>` : ''
-        }</div></li>`
+        }</div><button class="act-btn watch">Watch</button></li>`
       );
     } else if (status.online) {
       const entries = Object.entries(status.online).filter(([k, v]) => v);
       if (entries.length) {
         const [k, v] = entries[0];
+        const btn =
+          k === 'watching'
+            ? '<button class="act-btn join">Join</button>'
+            : '';
         cards.push(
           `<li class="activity-card online"><div class="act-info"><strong>${
             k.charAt(0).toUpperCase() + k.slice(1)
-          }</strong><span>${v}</span></div></li>`
+          }</strong><span>${v}</span></div>${btn}</li>`
         );
       } else {
         cards.push(

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -8,6 +8,7 @@ export default async function init({ hub, root, utils }) {
           <div class="po-left-body">
             <div class="po-avatar"><img alt="" /></div>
             <h2 class="po-name"></h2>
+            <p class="po-tagline"></p>
             <button class="po-edit">Edit Profile</button>
             <div class="po-section po-about-section">
               <h3>About Me</h3>
@@ -64,6 +65,7 @@ export default async function init({ hub, root, utils }) {
   const banner = overlay.querySelector('.po-banner');
   const avatar = overlay.querySelector('.po-avatar img');
   const nameEl = overlay.querySelector('.po-name');
+  const tagEl = overlay.querySelector('.po-tagline');
   const aboutSection = overlay.querySelector('.po-about-section');
   const aboutEl = overlay.querySelector('.po-about');
   const memberDateEl = overlay.querySelector('.po-member-date');
@@ -80,6 +82,13 @@ export default async function init({ hub, root, utils }) {
     avatar.src = user.avatar || '';
     avatar.alt = user.name || '';
     nameEl.textContent = user.name || '';
+    if (user.slug) {
+      tagEl.textContent = `@${user.slug}`;
+      tagEl.style.display = 'block';
+    } else {
+      tagEl.textContent = '';
+      tagEl.style.display = 'none';
+    }
     aboutEl.textContent = user.about || '';
     aboutSection.style.display = user.about ? 'block' : 'none';
     aboutRight.textContent = user.about || 'Nothing to see here';

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -2,24 +2,42 @@ export default async function init({ hub, root, utils }) {
   root.innerHTML = `
     <div class="profile-overlay hidden" role="dialog" aria-modal="true">
       <div class="po-card">
-        <button type="button" class="po-close" aria-label="Close">&times;</button>
-
         <div class="po-left">
           <div class="po-banner"></div>
           <div class="po-accent"></div>
           <div class="po-left-body">
             <div class="po-avatar"><img alt="" /></div>
             <h2 class="po-name"></h2>
+            <button class="po-edit">Edit Profile</button>
+            <div class="po-about"></div>
+            <div class="po-section po-member">
+              <h3>Member Since</h3>
+              <p class="po-member-date"></p>
+            </div>
+            <div class="po-section po-connections">
+              <h3>Connections</h3>
+              <div class="po-conn-list"></div>
+            </div>
           </div>
         </div>
 
         <div class="po-right">
+          <button type="button" class="po-close" aria-label="Close">&times;</button>
           <div class="po-tabs">
-            <button class="po-tab active">Activity</button>
-            <button class="po-tab">About</button>
-            <button class="po-tab">Mutual</button>
+            <button class="po-tab active" data-tab="activity">Activity</button>
+            <button class="po-tab" data-tab="about">About</button>
+            <button class="po-tab" data-tab="mutual">Mutual</button>
           </div>
-          <div class="po-panel"></div>
+          <div class="po-panel">
+            <div class="po-activity">
+              <p class="po-activity-head">You don't have any activity here</p>
+              <p class="po-activity-sub">Connect accounts to show off your game status, see what friends are playing and more.</p>
+              <div class="po-activity-actions">
+                <button class="po-btn">Connect Accounts</button>
+                <button class="po-btn">Add Game</button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -29,6 +47,9 @@ export default async function init({ hub, root, utils }) {
   const banner = overlay.querySelector('.po-banner');
   const avatar = overlay.querySelector('.po-avatar img');
   const nameEl = overlay.querySelector('.po-name');
+  const aboutEl = overlay.querySelector('.po-about');
+  const memberDateEl = overlay.querySelector('.po-member-date');
+  const connList = overlay.querySelector('.po-conn-list');
   const closeBtn = overlay.querySelector('.po-close');
 
   function fill(user = {}) {
@@ -38,6 +59,23 @@ export default async function init({ hub, root, utils }) {
     avatar.src = user.avatar || '';
     avatar.alt = user.name || '';
     nameEl.textContent = user.name || '';
+    aboutEl.textContent = user.about || '';
+    aboutEl.style.display = user.about ? 'block' : 'none';
+    if (user.memberSince) {
+      memberDateEl.textContent = user.memberSince;
+      memberDateEl.closest('.po-member').style.display = 'block';
+    } else {
+      memberDateEl.closest('.po-member').style.display = 'none';
+    }
+    if (user.connections && user.connections.length) {
+      connList.innerHTML = user.connections
+        .map((c) => `<img src="${c}" alt="connection" />`)
+        .join('');
+      connList.closest('.po-connections').style.display = 'block';
+    } else {
+      connList.innerHTML = '';
+      connList.closest('.po-connections').style.display = 'none';
+    }
   }
 
   function show(user) {

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -2,10 +2,12 @@ export default async function init({ hub, root, utils }) {
   const loggedIn = await fetch('/data/logged-in.json').then(r => r.json()).catch(() => null);
 
   const icons = {
-    edit: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M21.731 2.269a2.625 2.625 0 0 0-3.712 0l-1.157 1.157 3.712 3.712 1.157-1.157a2.625 2.625 0 0 0 0-3.712ZM19.513 8.199l-3.712-3.712-12.15 12.15a5.25 5.25 0 0 0-1.32 2.214l-.8 2.685a.75.75 0 0 0 .933.933l2.685-.8a5.25 5.25 0 0 0 2.214-1.32l12.15-12.15Z"/></svg>',
-    shop: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 6v.75H5.513c-.96 0-1.764.724-1.865 1.679l-1.263 12A1.875 1.875 0 0 0 4.25 22.5h15.5a1.875 1.875 0 0 0 1.865-2.071l-1.263-12a1.875 1.875 0 0 0-1.865-1.679H16.5V6a4.5 4.5 0 1 0-9 0ZM12 3a3 3 0 0 0-3 3v.75h6V6a3 3 0 0 0-3-3Zm-3 8.25a3 3 0 1 0 6 0v-.75a.75.75 0 0 1 1.5 0v.75a4.5 4.5 0 1 1-9 0v-.75a.75.75 0 0 1 1.5 0v.75Z" clip-rule="evenodd"/></svg>',
-    chat: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M4.848 2.771A49.144 49.144 0 0 1 12 2.25c2.43 0 4.817.178 7.152.52 1.978.292 3.348 2.024 3.348 3.97v6.02c0 1.946-1.37 3.678-3.348 3.97-1.94.284-3.916.455-5.922.505a.39.39 0 0 0-.266.112L8.78 21.53A.75.75 0 0 1 7.5 21v-3.955a48.842 48.842 0 0 1-2.652-.316c-1.978-.29-3.348-2.024-3.348-3.97V6.741c0-1.946 1.37-3.68 3.348-3.97Z" clip-rule="evenodd"/></svg>',
-    stream: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.5 4.5a3 3 0 0 0-3 3v9a3 3 0 0 0 3 3h8.25a3 3 0 0 0 3-3v-9a3 3 0 0 0-3-3H4.5ZM19.94 18.75l-2.69-2.69V7.94l2.69-2.69c.944-.945 2.56-.276 2.56 1.06v11.38c0 1.336-1.616 2.005-2.56 1.06Z"/></svg>'
+    follow:
+      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16 7a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z"/><path fill-rule="evenodd" d="M12 14a7 7 0 0 0-7 7 .75.75 0 0 0 1.5 0 5.5 5.5 0 0 1 11 0 .75.75 0 0 0 1.5 0 7 7 0 0 0-7-7Z" clip-rule="evenodd"/><path d="M19 7a1 1 0 1 0 0-2h-1V4a1 1 0 1 0-2 0v1h-1a1 1 0 1 0 0 2h1v1a1 1 0 1 0 2 0V7h1Z"/></svg>',
+    support:
+      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M11.645 20.353a.75.75 0 0 0 .71 0 45.956 45.956 0 0 0 1.035-.62c1.588-.977 3.267-2.015 4.825-3.152C21.247 14.73 23 12.537 23 9.943 23 7.206 20.955 5 18.352 5c-1.542 0-3.01.876-3.708 2.18a.75.75 0 0 1-1.288 0C12.655 5.876 11.187 5 9.645 5 7.043 5 5 7.206 5 9.943c0 2.594 1.753 4.786 3.785 6.638 1.558 1.137 3.237 2.175 4.825 3.152.345.212.689.42 1.035.62Z" clip-rule="evenodd"/></svg>',
+    shop:
+      '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 6v.75H5.513c-.96 0-1.764.724-1.865 1.679l-1.263 12A1.875 1.875 0 0 0 4.25 22.5h15.5a1.875 1.875 0 0 0 1.865-2.071l-1.263-12a1.875 1.875 0 0 0-1.865-1.679H16.5V6a4.5 4.5 0 1 0-9 0ZM12 3a3 3 0 0 0-3 3v.75h6V6a3 3 0 0 0-3-3Zm-3 8.25a3 3 0 1 0 6 0v-.75a.75.75 0 0 1 1.5 0v.75a4.5 4.5 0 1 1-9 0v-.75a.75.75 0 0 1 1.5 0v.75Z" clip-rule="evenodd"/></svg>'
   };
 
   root.innerHTML = `
@@ -40,26 +42,19 @@ export default async function init({ hub, root, utils }) {
 
         <div class="po-right">
           <div class="po-tabs">
-            <button class="po-tab active" data-tab="activity">Activity</button>
-            <button class="po-tab" data-tab="about">About</button>
-            <button class="po-tab" data-tab="mutual">Mutual</button>
+            <button class="po-tab active" data-tab="topics">Topics</button>
+            <button class="po-tab" data-tab="badges">Badges</button>
+            <button class="po-tab" data-tab="members">Members</button>
           </div>
           <div class="po-panels">
-            <div class="po-panel active" data-panel="activity">
-              <div class="po-activity">
-                <p class="po-activity-head">You don't have any activity here</p>
-                <p class="po-activity-sub">Connect accounts to show off your game status, see what friends are playing and more.</p>
-                <div class="po-activity-actions">
-                  <button class="po-btn">Connect Accounts</button>
-                  <button class="po-btn">Add Game</button>
-                </div>
-              </div>
+            <div class="po-panel active" data-panel="topics">
+              <p class="po-empty">No topics to show.</p>
             </div>
-            <div class="po-panel" data-panel="about">
-              <p class="po-about-right"></p>
+            <div class="po-panel" data-panel="badges">
+              <p class="po-empty">No badges to show.</p>
             </div>
-            <div class="po-panel" data-panel="mutual">
-              <p class="po-empty">No mutuals to show.</p>
+            <div class="po-panel" data-panel="members">
+              <p class="po-empty">No members to show.</p>
             </div>
           </div>
           <div class="po-footer">
@@ -83,7 +78,6 @@ export default async function init({ hub, root, utils }) {
   const closeBtn = overlay.querySelector('.po-close');
   const tabs = overlay.querySelectorAll('.po-tab');
   const panels = overlay.querySelectorAll('.po-panel');
-  const aboutRight = overlay.querySelector('.po-about-right');
 
   function fill(user = {}) {
     overlay.style.setProperty('--accent', user.accent || '#5865f2');
@@ -101,18 +95,14 @@ export default async function init({ hub, root, utils }) {
     }
     aboutEl.textContent = user.about || '';
     aboutSection.style.display = user.about ? 'block' : 'none';
-    aboutRight.textContent = user.about || 'Nothing to see here';
 
     actions.innerHTML = '';
     const isSelf = user.slug === loggedIn;
-    if (isSelf) {
-      actions.innerHTML += `<button class="po-action edit">${icons.edit}<span>Edit Profile</span></button>`;
+    if (!isSelf) {
+      actions.innerHTML += `<button class="po-action follow">${icons.follow}<span>Follow</span></button>`;
+      actions.innerHTML += `<button class="po-action support">${icons.support}<span>Support</span></button>`;
     }
-    actions.innerHTML += `<button class="po-action icon-only shop" title="Shop">${icons.shop}</button>`;
-    actions.innerHTML += `<button class="po-action icon-only chat" title="Chat">${icons.chat}</button>`;
-    if (user.streaming) {
-      actions.innerHTML += `<button class="po-action icon-only stream" title="Stream">${icons.stream}</button>`;
-    }
+    actions.innerHTML += `<button class="po-action shop">${icons.shop}<span>Shop</span></button>`;
     if (user.memberSince) {
       memberDateEl.textContent = user.memberSince;
       memberDateEl.closest('.po-member').style.display = 'block';
@@ -141,7 +131,7 @@ export default async function init({ hub, root, utils }) {
 
   function show(user) {
     fill(user);
-    switchTab('activity');
+    switchTab('topics');
     overlay.classList.remove('hidden');
     overlay.classList.add('visible');
   }

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -83,6 +83,7 @@ export default async function init({ hub, root, utils }) {
   const tabs = overlay.querySelectorAll('.po-tab');
   const panels = overlay.querySelectorAll('.po-panel');
   const topicsPanel = overlay.querySelector('[data-panel="topics"]');
+  const badgesPanel = overlay.querySelector('[data-panel="badges"]');
 
   function fill(user = {}) {
     overlay.style.setProperty('--accent', user.accent || '#5865f2');
@@ -143,6 +144,30 @@ export default async function init({ hub, root, utils }) {
         .join('')}</ul>`;
     } else {
       topicsPanel.innerHTML = '<p class="po-empty">No topics to show.</p>';
+    }
+
+    const earned = user['earned-badges'];
+    if (earned && earned.length) {
+      badgesPanel.innerHTML = `<ul class="po-badge-list">${earned
+        .map((b) => {
+          const meta = [
+            b.awardedFor,
+            b.awardedOn ? `Unlocked ${b.awardedOn}` : null
+          ].filter(Boolean).join(' • ');
+          return `
+            <li class="po-badge-item">
+              <img src="${b.icon}" alt="${b.name} badge" />
+              <div class="po-badge-info">
+                <h4 class="po-badge-name">${b.name}</h4>
+                <p class="po-badge-desc">${b.description}</p>
+                <p class="po-badge-meta">${meta}</p>
+              </div>
+            </li>
+          `;
+        })
+        .join('')}</ul>`;
+    } else {
+      badgesPanel.innerHTML = '<p class="po-empty">No badges to show.</p>';
     }
   }
 

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -3,15 +3,23 @@ export default async function init({ hub, root, utils }) {
     <div class="profile-overlay hidden" role="dialog" aria-modal="true">
       <div class="po-card">
         <button type="button" class="po-close" aria-label="Close">&times;</button>
-        <div class="po-banner"></div>
-        <div class="po-content">
-          <div class="po-avatar"><img alt="" /></div>
-          <h2 class="po-name"></h2>
+
+        <div class="po-left">
+          <div class="po-banner"></div>
+          <div class="po-accent"></div>
+          <div class="po-left-body">
+            <div class="po-avatar"><img alt="" /></div>
+            <h2 class="po-name"></h2>
+          </div>
         </div>
-        <div class="po-tabs">
-          <button class="po-tab active">About</button>
-          <button class="po-tab">Posts</button>
-          <button class="po-tab">Stats</button>
+
+        <div class="po-right">
+          <div class="po-tabs">
+            <button class="po-tab active">Activity</button>
+            <button class="po-tab">About</button>
+            <button class="po-tab">Mutual</button>
+          </div>
+          <div class="po-panel"></div>
         </div>
       </div>
     </div>

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -37,7 +37,7 @@ export default async function init({ hub, root, utils }) {
               <div class="po-conn-list"></div>
             </div>
             <div class="po-section po-activity">
-              <h3>Customizing My Profile</h3>
+              <h3>Activity</h3>
               <ul class="po-activity-list"></ul>
             </div>
             <div class="po-section po-note">
@@ -91,28 +91,53 @@ export default async function init({ hub, root, utils }) {
   const topicsPanel = overlay.querySelector('[data-panel="topics"]');
   const badgesPanel = overlay.querySelector('[data-panel="badges"]');
 
-  function activityLines(user = {}) {
-    const lines = [];
+  function activityCards(user = {}) {
+    const cards = [];
     const status = user.status || {};
+
     if (status.streaming) {
-      lines.push(`Streaming ${status.streaming.title || ''}`);
+      const s = status.streaming;
+      cards.push(
+        `<li class="activity-card streaming">${
+          s.thumbnailId ? `<img src="${s.thumbnailId}" alt="" />` : ''
+        }<div class="act-info"><strong>${s.title || 'Streaming'}</strong>${
+          s.viewers ? `<span>${s.viewers} viewers</span>` : ''
+        }</div></li>`
+      );
     } else if (status.online) {
       const entries = Object.entries(status.online).filter(([k, v]) => v);
       if (entries.length) {
         const [k, v] = entries[0];
-        lines.push(`${k.charAt(0).toUpperCase() + k.slice(1)} ${v}`);
+        cards.push(
+          `<li class="activity-card online"><div class="act-info"><strong>${
+            k.charAt(0).toUpperCase() + k.slice(1)
+          }</strong><span>${v}</span></div></li>`
+        );
       } else {
-        lines.push('Online');
+        cards.push(
+          '<li class="activity-card online"><div class="act-info"><strong>Online</strong></div></li>'
+        );
       }
     } else if (status.away !== null) {
-      lines.push('Away');
+      cards.push(
+        '<li class="activity-card away"><div class="act-info"><strong>Away</strong></div></li>'
+      );
     } else if (status.dnd !== null) {
-      lines.push('Do Not Disturb');
+      cards.push(
+        '<li class="activity-card dnd"><div class="act-info"><strong>Do Not Disturb</strong></div></li>'
+      );
     }
+
     if (user.hosting) {
-      lines.push(`Hosting ${user.hosting.title || ''}`);
+      const h = user.hosting;
+      cards.push(
+        `<li class="activity-card hosting">${
+          h.thumbnailId ? `<img src="${h.thumbnailId}" alt="" />` : ''
+        }<div class="act-info"><strong>Hosting ${h.title || ''}</strong></div></li>`
+      );
     }
-    return lines;
+
+    return cards;
   }
 
   function fill(user = {}) {
@@ -162,9 +187,9 @@ export default async function init({ hub, root, utils }) {
       connList.closest('.po-connections').style.display = 'none';
     }
 
-    const acts = activityLines(user);
+    const acts = activityCards(user);
     if (acts.length) {
-      activityList.innerHTML = acts.map((a) => `<li>${a}</li>`).join('');
+      activityList.innerHTML = acts.join('');
       activitySection.style.display = 'block';
     } else {
       activityList.innerHTML = '';
@@ -224,6 +249,7 @@ export default async function init({ hub, root, utils }) {
       const full = await getUserByToken(user.token).catch(() => ({}));
       user = { ...full, ...user };
     }
+    user.streaming = user.streaming || !!(user.status && user.status.streaming);
     fill(user);
     switchTab('topics');
     overlay.classList.remove('hidden');

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -239,5 +239,28 @@ export default async function init({ hub, root, utils }) {
   utils.listen(overlay, 'click', (e) => { if (e.target === overlay) hide(); });
   utils.listen(document, 'keydown', (e) => { if (e.key === 'Escape') hide(); });
 
+  utils.delegate(document, 'click', '[data-profile-name]', (e, el) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    const user = {
+      name: el.dataset.profileName,
+      token: el.dataset.profileToken,
+      avatar: el.dataset.profileAvatar,
+      banner: el.dataset.profileBanner,
+      accent: el.dataset.profileAccent,
+      frame: el.dataset.profileFrame,
+      bio: el.dataset.profileBio,
+      memberSince: el.dataset.profileSince,
+      connections: el.dataset.profileConnections
+        ? el.dataset.profileConnections.split(',')
+        : [],
+      badges: el.dataset.profileBadges
+        ? el.dataset.profileBadges.split(',')
+        : [],
+      streaming: el.dataset.profileStreaming === 'true'
+    };
+    show(user);
+  });
+
   return { show, hide };
 }

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -1,0 +1,51 @@
+export default async function init({ hub, root, utils }) {
+  root.innerHTML = `
+    <div class="profile-overlay hidden" role="dialog" aria-modal="true">
+      <div class="po-card">
+        <button type="button" class="po-close" aria-label="Close">&times;</button>
+        <div class="po-banner"></div>
+        <div class="po-content">
+          <div class="po-avatar"><img alt="" /></div>
+          <h2 class="po-name"></h2>
+        </div>
+        <div class="po-tabs">
+          <button class="po-tab active">About</button>
+          <button class="po-tab">Posts</button>
+          <button class="po-tab">Stats</button>
+        </div>
+      </div>
+    </div>
+  `;
+
+  const overlay = root.querySelector('.profile-overlay');
+  const banner = overlay.querySelector('.po-banner');
+  const avatar = overlay.querySelector('.po-avatar img');
+  const nameEl = overlay.querySelector('.po-name');
+  const closeBtn = overlay.querySelector('.po-close');
+
+  function fill(user = {}) {
+    overlay.style.setProperty('--accent', user.accent || '#5865f2');
+    overlay.style.setProperty('--frame', user.frame ? `url('${user.frame}')` : 'none');
+    banner.style.backgroundImage = user.banner ? `url("${user.banner}")` : 'none';
+    avatar.src = user.avatar || '';
+    avatar.alt = user.name || '';
+    nameEl.textContent = user.name || '';
+  }
+
+  function show(user) {
+    fill(user);
+    overlay.classList.remove('hidden');
+    overlay.classList.add('visible');
+  }
+
+  function hide() {
+    overlay.classList.add('hidden');
+    overlay.classList.remove('visible');
+  }
+
+  utils.listen(closeBtn, 'click', hide);
+  utils.listen(overlay, 'click', (e) => { if (e.target === overlay) hide(); });
+  utils.listen(document, 'keydown', (e) => { if (e.key === 'Escape') hide(); });
+
+  return { show, hide };
+}

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -1,4 +1,13 @@
 export default async function init({ hub, root, utils }) {
+  const loggedIn = await fetch('/data/logged-in.json').then(r => r.json()).catch(() => null);
+
+  const icons = {
+    edit: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M21.731 2.269a2.625 2.625 0 0 0-3.712 0l-1.157 1.157 3.712 3.712 1.157-1.157a2.625 2.625 0 0 0 0-3.712ZM19.513 8.199l-3.712-3.712-12.15 12.15a5.25 5.25 0 0 0-1.32 2.214l-.8 2.685a.75.75 0 0 0 .933.933l2.685-.8a5.25 5.25 0 0 0 2.214-1.32l12.15-12.15Z"/></svg>',
+    shop: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M7.5 6v.75H5.513c-.96 0-1.764.724-1.865 1.679l-1.263 12A1.875 1.875 0 0 0 4.25 22.5h15.5a1.875 1.875 0 0 0 1.865-2.071l-1.263-12a1.875 1.875 0 0 0-1.865-1.679H16.5V6a4.5 4.5 0 1 0-9 0ZM12 3a3 3 0 0 0-3 3v.75h6V6a3 3 0 0 0-3-3Zm-3 8.25a3 3 0 1 0 6 0v-.75a.75.75 0 0 1 1.5 0v.75a4.5 4.5 0 1 1-9 0v-.75a.75.75 0 0 1 1.5 0v.75Z" clip-rule="evenodd"/></svg>',
+    chat: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M4.848 2.771A49.144 49.144 0 0 1 12 2.25c2.43 0 4.817.178 7.152.52 1.978.292 3.348 2.024 3.348 3.97v6.02c0 1.946-1.37 3.678-3.348 3.97-1.94.284-3.916.455-5.922.505a.39.39 0 0 0-.266.112L8.78 21.53A.75.75 0 0 1 7.5 21v-3.955a48.842 48.842 0 0 1-2.652-.316c-1.978-.29-3.348-2.024-3.348-3.97V6.741c0-1.946 1.37-3.68 3.348-3.97Z" clip-rule="evenodd"/></svg>',
+    stream: '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M4.5 4.5a3 3 0 0 0-3 3v9a3 3 0 0 0 3 3h8.25a3 3 0 0 0 3-3v-9a3 3 0 0 0-3-3H4.5ZM19.94 18.75l-2.69-2.69V7.94l2.69-2.69c.944-.945 2.56-.276 2.56 1.06v11.38c0 1.336-1.616 2.005-2.56 1.06Z"/></svg>'
+  };
+
   root.innerHTML = `
     <div class="profile-overlay hidden" role="dialog" aria-modal="true">
       <div class="po-card">
@@ -9,7 +18,7 @@ export default async function init({ hub, root, utils }) {
             <div class="po-avatar"><img alt="" /></div>
             <h2 class="po-name"></h2>
             <p class="po-tagline"></p>
-            <button class="po-edit">Edit Profile</button>
+            <div class="po-actions"></div>
             <div class="po-section po-about-section">
               <h3>About Me</h3>
               <p class="po-about"></p>
@@ -70,6 +79,7 @@ export default async function init({ hub, root, utils }) {
   const aboutEl = overlay.querySelector('.po-about');
   const memberDateEl = overlay.querySelector('.po-member-date');
   const connList = overlay.querySelector('.po-conn-list');
+  const actions = overlay.querySelector('.po-actions');
   const closeBtn = overlay.querySelector('.po-close');
   const tabs = overlay.querySelectorAll('.po-tab');
   const panels = overlay.querySelectorAll('.po-panel');
@@ -92,6 +102,17 @@ export default async function init({ hub, root, utils }) {
     aboutEl.textContent = user.about || '';
     aboutSection.style.display = user.about ? 'block' : 'none';
     aboutRight.textContent = user.about || 'Nothing to see here';
+
+    actions.innerHTML = '';
+    const isSelf = user.slug === loggedIn;
+    if (isSelf) {
+      actions.innerHTML += `<button class="po-action edit">${icons.edit}<span>Edit Profile</span></button>`;
+    }
+    actions.innerHTML += `<button class="po-action icon-only shop" title="Shop">${icons.shop}</button>`;
+    actions.innerHTML += `<button class="po-action icon-only chat" title="Chat">${icons.chat}</button>`;
+    if (user.streaming) {
+      actions.innerHTML += `<button class="po-action icon-only stream" title="Stream">${icons.stream}</button>`;
+    }
     if (user.memberSince) {
       memberDateEl.textContent = user.memberSince;
       memberDateEl.closest('.po-member').style.display = 'block';

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -42,10 +42,6 @@ export default async function init({ hub, root, utils }) {
               <h3>Activity</h3>
               <ul class="po-activity-list"></ul>
             </div>
-            <div class="po-section po-note">
-              <h3>Note</h3>
-              <p class="po-note-text">Click to add a note</p>
-            </div>
           </div>
         </div>
 

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -2,6 +2,7 @@ export default async function init({ hub, root, utils }) {
   root.innerHTML = `
     <div class="profile-overlay hidden" role="dialog" aria-modal="true">
       <div class="po-card">
+        <button type="button" class="po-close" aria-label="Close">&times;</button>
         <div class="po-left">
           <div class="po-banner"></div>
           <div class="po-accent"></div>
@@ -22,20 +23,27 @@ export default async function init({ hub, root, utils }) {
         </div>
 
         <div class="po-right">
-          <button type="button" class="po-close" aria-label="Close">&times;</button>
           <div class="po-tabs">
             <button class="po-tab active" data-tab="activity">Activity</button>
             <button class="po-tab" data-tab="about">About</button>
             <button class="po-tab" data-tab="mutual">Mutual</button>
           </div>
-          <div class="po-panel">
-            <div class="po-activity">
-              <p class="po-activity-head">You don't have any activity here</p>
-              <p class="po-activity-sub">Connect accounts to show off your game status, see what friends are playing and more.</p>
-              <div class="po-activity-actions">
-                <button class="po-btn">Connect Accounts</button>
-                <button class="po-btn">Add Game</button>
+          <div class="po-panels">
+            <div class="po-panel active" data-panel="activity">
+              <div class="po-activity">
+                <p class="po-activity-head">You don't have any activity here</p>
+                <p class="po-activity-sub">Connect accounts to show off your game status, see what friends are playing and more.</p>
+                <div class="po-activity-actions">
+                  <button class="po-btn">Connect Accounts</button>
+                  <button class="po-btn">Add Game</button>
+                </div>
               </div>
+            </div>
+            <div class="po-panel" data-panel="about">
+              <p class="po-about-right"></p>
+            </div>
+            <div class="po-panel" data-panel="mutual">
+              <p class="po-empty">No mutuals to show.</p>
             </div>
           </div>
         </div>
@@ -51,6 +59,9 @@ export default async function init({ hub, root, utils }) {
   const memberDateEl = overlay.querySelector('.po-member-date');
   const connList = overlay.querySelector('.po-conn-list');
   const closeBtn = overlay.querySelector('.po-close');
+  const tabs = overlay.querySelectorAll('.po-tab');
+  const panels = overlay.querySelectorAll('.po-panel');
+  const aboutRight = overlay.querySelector('.po-about-right');
 
   function fill(user = {}) {
     overlay.style.setProperty('--accent', user.accent || '#5865f2');
@@ -61,6 +72,7 @@ export default async function init({ hub, root, utils }) {
     nameEl.textContent = user.name || '';
     aboutEl.textContent = user.about || '';
     aboutEl.style.display = user.about ? 'block' : 'none';
+    aboutRight.textContent = user.about || 'Nothing to see here';
     if (user.memberSince) {
       memberDateEl.textContent = user.memberSince;
       memberDateEl.closest('.po-member').style.display = 'block';
@@ -78,8 +90,18 @@ export default async function init({ hub, root, utils }) {
     }
   }
 
+  function switchTab(tabName) {
+    tabs.forEach((t) => t.classList.toggle('active', t.dataset.tab === tabName));
+    panels.forEach((p) => p.classList.toggle('active', p.dataset.panel === tabName));
+  }
+
+  tabs.forEach((tab) => {
+    utils.listen(tab, 'click', () => switchTab(tab.dataset.tab));
+  });
+
   function show(user) {
     fill(user);
+    switchTab('activity');
     overlay.classList.remove('hidden');
     overlay.classList.add('visible');
   }

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -88,18 +88,18 @@ export default async function init({ hub, root, utils }) {
     avatar.src = user.avatar || '';
     avatar.alt = user.name || '';
     nameEl.textContent = user.name || '';
-    if (user.slug) {
-      tagEl.textContent = `@${user.slug}`;
+    if (user.token) {
+      tagEl.textContent = `@${user.token}`;
       tagEl.style.display = 'block';
     } else {
       tagEl.textContent = '';
       tagEl.style.display = 'none';
     }
-    aboutEl.textContent = user.about || '';
-    aboutSection.style.display = user.about ? 'block' : 'none';
+    aboutEl.textContent = user.bio || '';
+    aboutSection.style.display = user.bio ? 'block' : 'none';
 
     actions.innerHTML = '';
-    const isSelf = user.slug === loggedIn;
+    const isSelf = user.token === loggedIn;
     if (!isSelf) {
       actions.innerHTML += `<button class="po-action follow">${icons.follow}<span>Follow</span></button>`;
       actions.innerHTML += `<button class="po-action support">${icons.support}<span>Support</span></button>`;

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -2,7 +2,6 @@ export default async function init({ hub, root, utils }) {
   root.innerHTML = `
     <div class="profile-overlay hidden" role="dialog" aria-modal="true">
       <div class="po-card">
-        <button type="button" class="po-close" aria-label="Close">&times;</button>
         <div class="po-left">
           <div class="po-banner"></div>
           <div class="po-accent"></div>
@@ -10,7 +9,10 @@ export default async function init({ hub, root, utils }) {
             <div class="po-avatar"><img alt="" /></div>
             <h2 class="po-name"></h2>
             <button class="po-edit">Edit Profile</button>
-            <div class="po-about"></div>
+            <div class="po-section po-about-section">
+              <h3>About Me</h3>
+              <p class="po-about"></p>
+            </div>
             <div class="po-section po-member">
               <h3>Member Since</h3>
               <p class="po-member-date"></p>
@@ -18,6 +20,10 @@ export default async function init({ hub, root, utils }) {
             <div class="po-section po-connections">
               <h3>Connections</h3>
               <div class="po-conn-list"></div>
+            </div>
+            <div class="po-section po-note">
+              <h3>Note</h3>
+              <p class="po-note-text">Click to add a note</p>
             </div>
           </div>
         </div>
@@ -46,6 +52,9 @@ export default async function init({ hub, root, utils }) {
               <p class="po-empty">No mutuals to show.</p>
             </div>
           </div>
+          <div class="po-footer">
+            <button type="button" class="po-close">Close</button>
+          </div>
         </div>
       </div>
     </div>
@@ -55,6 +64,7 @@ export default async function init({ hub, root, utils }) {
   const banner = overlay.querySelector('.po-banner');
   const avatar = overlay.querySelector('.po-avatar img');
   const nameEl = overlay.querySelector('.po-name');
+  const aboutSection = overlay.querySelector('.po-about-section');
   const aboutEl = overlay.querySelector('.po-about');
   const memberDateEl = overlay.querySelector('.po-member-date');
   const connList = overlay.querySelector('.po-conn-list');
@@ -71,7 +81,7 @@ export default async function init({ hub, root, utils }) {
     avatar.alt = user.name || '';
     nameEl.textContent = user.name || '';
     aboutEl.textContent = user.about || '';
-    aboutEl.style.display = user.about ? 'block' : 'none';
+    aboutSection.style.display = user.about ? 'block' : 'none';
     aboutRight.textContent = user.about || 'Nothing to see here';
     if (user.memberSince) {
       memberDateEl.textContent = user.memberSince;

--- a/module/profile-overlay/profile-overlay.js
+++ b/module/profile-overlay/profile-overlay.js
@@ -36,6 +36,10 @@ export default async function init({ hub, root, utils }) {
               <h3>Connections</h3>
               <div class="po-conn-list"></div>
             </div>
+            <div class="po-section po-activity">
+              <h3>Customizing My Profile</h3>
+              <ul class="po-activity-list"></ul>
+            </div>
             <div class="po-section po-note">
               <h3>Note</h3>
               <p class="po-note-text">Click to add a note</p>
@@ -77,6 +81,8 @@ export default async function init({ hub, root, utils }) {
   const aboutEl = overlay.querySelector('.po-about');
   const memberDateEl = overlay.querySelector('.po-member-date');
   const connList = overlay.querySelector('.po-conn-list');
+  const activitySection = overlay.querySelector('.po-activity');
+  const activityList = overlay.querySelector('.po-activity-list');
   const actions = overlay.querySelector('.po-actions');
   const badgesEl = overlay.querySelector('.po-badges');
   const closeBtn = overlay.querySelector('.po-close');
@@ -84,6 +90,30 @@ export default async function init({ hub, root, utils }) {
   const panels = overlay.querySelectorAll('.po-panel');
   const topicsPanel = overlay.querySelector('[data-panel="topics"]');
   const badgesPanel = overlay.querySelector('[data-panel="badges"]');
+
+  function activityLines(user = {}) {
+    const lines = [];
+    const status = user.status || {};
+    if (status.streaming) {
+      lines.push(`Streaming ${status.streaming.title || ''}`);
+    } else if (status.online) {
+      const entries = Object.entries(status.online).filter(([k, v]) => v);
+      if (entries.length) {
+        const [k, v] = entries[0];
+        lines.push(`${k.charAt(0).toUpperCase() + k.slice(1)} ${v}`);
+      } else {
+        lines.push('Online');
+      }
+    } else if (status.away !== null) {
+      lines.push('Away');
+    } else if (status.dnd !== null) {
+      lines.push('Do Not Disturb');
+    }
+    if (user.hosting) {
+      lines.push(`Hosting ${user.hosting.title || ''}`);
+    }
+    return lines;
+  }
 
   function fill(user = {}) {
     overlay.style.setProperty('--accent', user.accent || '#5865f2');
@@ -130,6 +160,15 @@ export default async function init({ hub, root, utils }) {
     } else {
       connList.innerHTML = '';
       connList.closest('.po-connections').style.display = 'none';
+    }
+
+    const acts = activityLines(user);
+    if (acts.length) {
+      activityList.innerHTML = acts.map((a) => `<li>${a}</li>`).join('');
+      activitySection.style.display = 'block';
+    } else {
+      activityList.innerHTML = '';
+      activitySection.style.display = 'none';
     }
 
     if (user.topics && user.topics.length) {

--- a/module/user-rail/user-rail.js
+++ b/module/user-rail/user-rail.js
@@ -16,7 +16,7 @@ export default async function init({ hub, root, utils }) {
         ${users
           .map(
             (u, i) => `
-        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}">
+        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}">
           <div class="avatar-wrap" style="--frame:url('${u.frame}');">
             <img class="avatar-image" src="${u.avatar}" alt="${u.name}">
           </div>

--- a/module/user-rail/user-rail.js
+++ b/module/user-rail/user-rail.js
@@ -28,15 +28,9 @@ export default async function init({ hub, root, utils }) {
   `;
 
   utils.delegate(root, 'click', '.user-rail-item', (e, el) => {
-    e.stopPropagation();
     root.querySelectorAll('.user-rail-item.active').forEach(item => item.classList.remove('active'));
     el.classList.add('active');
     el.classList.remove('has-notification');
-    const index = parseInt(el.dataset.index, 10);
-    const user = users[index];
-    if (user) {
-      hub.api['profile-overlay'].show(user);
-    }
   });
 
   return {};

--- a/module/user-rail/user-rail.js
+++ b/module/user-rail/user-rail.js
@@ -16,7 +16,7 @@ export default async function init({ hub, root, utils }) {
         ${users
           .map(
             (u, i) => `
-        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-slug="${u.slug}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}">
+        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-slug="${u.slug}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-badges="${(u.badges || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}">
           <div class="avatar-wrap" style="--frame:url('${u.frame}');">
             <img class="avatar-image" src="${u.avatar}" alt="${u.name}">
           </div>

--- a/module/user-rail/user-rail.js
+++ b/module/user-rail/user-rail.js
@@ -16,7 +16,7 @@ export default async function init({ hub, root, utils }) {
         ${users
           .map(
             (u, i) => `
-        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}">
+        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-slug="${u.slug}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}">
           <div class="avatar-wrap" style="--frame:url('${u.frame}');">
             <img class="avatar-image" src="${u.avatar}" alt="${u.name}">
           </div>

--- a/module/user-rail/user-rail.js
+++ b/module/user-rail/user-rail.js
@@ -16,7 +16,7 @@ export default async function init({ hub, root, utils }) {
         ${users
           .map(
             (u, i) => `
-        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-slug="${u.slug}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}">
+        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-slug="${u.slug}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}">
           <div class="avatar-wrap" style="--frame:url('${u.frame}');">
             <img class="avatar-image" src="${u.avatar}" alt="${u.name}">
           </div>

--- a/module/user-rail/user-rail.js
+++ b/module/user-rail/user-rail.js
@@ -1,14 +1,14 @@
-import { getUserBySlug } from '../users.js';
+import { getUserByToken } from '../users.js';
 
 export default async function init({ hub, root, utils }) {
-  const loggedSlug = await fetch('/data/logged-in.json').then(r => r.json());
-  const loggedUser = await getUserBySlug(loggedSlug);
-  const { subscribed = [], followed = [] } = loggedUser || {};
-  const slugs = [
-    ...subscribed,
-    ...followed.filter(slug => !subscribed.includes(slug))
+  const loggedToken = await fetch('/data/logged-in.json').then(r => r.json());
+  const loggedUser = await getUserByToken(loggedToken);
+  const { subscribedTo = [], following = [] } = loggedUser || {};
+  const tokens = [
+    ...subscribedTo,
+    ...following.filter(token => !subscribedTo.includes(token))
   ];
-  const users = (await Promise.all(slugs.map(getUserBySlug))).filter(Boolean);
+  const users = (await Promise.all(tokens.map(getUserByToken))).filter(Boolean);
 
   root.innerHTML = `
     <nav class="user-rail">
@@ -16,7 +16,7 @@ export default async function init({ hub, root, utils }) {
         ${users
           .map(
             (u, i) => `
-        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-slug="${u.slug}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}" data-profile-about="${u.about || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-badges="${(u.badges || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}">
+        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-token="${u.token}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}" data-profile-bio="${u.bio || ''}" data-profile-since="${u.memberSince || ''}" data-profile-connections="${(u.connections || []).join(',')}" data-profile-badges="${(u.badges || []).join(',')}" data-profile-streaming="${u.streaming ? 'true' : 'false'}">
           <div class="avatar-wrap" style="--frame:url('${u.frame}');">
             <img class="avatar-image" src="${u.avatar}" alt="${u.name}">
           </div>

--- a/module/user-rail/user-rail.js
+++ b/module/user-rail/user-rail.js
@@ -16,7 +16,7 @@ export default async function init({ root, utils }) {
         ${users
           .map(
             (u, i) => `
-        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};">
+        <li class="user-rail-item${u.hasNotification ? ' has-notification' : ''}" data-index="${i}" style="--accent:${u.accent};" data-profile-name="${u.name}" data-profile-avatar="${u.avatar}" data-profile-banner="${u.banner}" data-profile-accent="${u.accent}" data-profile-frame="${u.frame}">
           <div class="avatar-wrap" style="--frame:url('${u.frame}');">
             <img class="avatar-image" src="${u.avatar}" alt="${u.name}">
           </div>
@@ -31,8 +31,6 @@ export default async function init({ root, utils }) {
     root.querySelectorAll('.user-rail-item.active').forEach(item => item.classList.remove('active'));
     el.classList.add('active');
     el.classList.remove('has-notification');
-    const u = users[parseInt(el.getAttribute('data-index'), 10)];
-    window.LoadMainModule('profile', { user: u });
   });
 
   return {};

--- a/module/user-rail/user-rail.js
+++ b/module/user-rail/user-rail.js
@@ -1,6 +1,6 @@
 import { getUserBySlug } from '../users.js';
 
-export default async function init({ root, utils }) {
+export default async function init({ hub, root, utils }) {
   const loggedSlug = await fetch('/data/logged-in.json').then(r => r.json());
   const loggedUser = await getUserBySlug(loggedSlug);
   const { subscribed = [], followed = [] } = loggedUser || {};
@@ -35,7 +35,7 @@ export default async function init({ root, utils }) {
     const index = parseInt(el.dataset.index, 10);
     const user = users[index];
     if (user) {
-      window.LoadMainModule('profile', { user });
+      hub.api['profile-overlay'].show(user);
     }
   });
 

--- a/module/user-rail/user-rail.js
+++ b/module/user-rail/user-rail.js
@@ -28,9 +28,15 @@ export default async function init({ root, utils }) {
   `;
 
   utils.delegate(root, 'click', '.user-rail-item', (e, el) => {
+    e.stopPropagation();
     root.querySelectorAll('.user-rail-item.active').forEach(item => item.classList.remove('active'));
     el.classList.add('active');
     el.classList.remove('has-notification');
+    const index = parseInt(el.dataset.index, 10);
+    const user = users[index];
+    if (user) {
+      window.LoadMainModule('profile', { user });
+    }
   });
 
   return {};

--- a/module/users.js
+++ b/module/users.js
@@ -1,8 +1,8 @@
 const cache = new Map();
 
-export async function getUserBySlug(slug) {
-  if (!cache.has(slug)) {
-    cache.set(slug, fetch(`/data/users/${slug}.json`).then(r => r.json()));
+export async function getUserByToken(token) {
+  if (!cache.has(token)) {
+    cache.set(token, fetch(`/data/users/${token}.json`).then(r => r.json()));
   }
-  return cache.get(slug);
+  return cache.get(token);
 }


### PR DESCRIPTION
## Summary
- add `mini-profile` module rendering a Discord-style popup
- trigger popup from avatars and usernames in chat, navigation, and user rail
- adjust navigation and user rail behavior to avoid loading full profiles on click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc56c541348324821b04b624b809d6